### PR TITLE
Update MSOffice2011Updates.munki.recipe removed Autoupdate, added Lync

### DIFF
--- a/MSOffice2011Updates/MSOffice2011Updates.munki.recipe
+++ b/MSOffice2011Updates/MSOffice2011Updates.munki.recipe
@@ -24,7 +24,7 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
             <key>blocking_applications</key>
             <array>
               <string>MSN Messenger</string>
-              <string>Microsoft AutoUpdate</string>
+              <string>Microsoft Lync</string>
               <string>Microsoft Cert Manager</string>
               <string>Microsoft Chart Converter</string>
               <string>Microsoft Clip Gallery</string>


### PR DESCRIPTION
Removed Microsoft Autoupdate from blocking_applications because the user cannot easily quit the this as it is deamonized. Added Microsoft Lync to blocking_applications, Lync dies when the installer runs.
