### PR TITLE
Change Name variables for puppetlabs installers to more closely follow t...

### DIFF
--- a/Puppetlabs/Facter.munki.recipe
+++ b/Puppetlabs/Facter.munki.recipe
@@ -15,7 +15,7 @@ the default, 'latest'.</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>support/Facter</string>
         <key>NAME</key>
-        <string>Facter</string>
+        <string>facter</string>
         <key>VERSION</key>
         <string>latest</string>
         <key>pkginfo</key>

--- a/Puppetlabs/Hiera.munki.recipe
+++ b/Puppetlabs/Hiera.munki.recipe
@@ -15,7 +15,7 @@ the default, 'latest'.</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>support/Hiera</string>
         <key>NAME</key>
-        <string>Hiera</string>
+        <string>hiera</string>
         <key>VERSION</key>
         <string>latest</string>
         <key>pkginfo</key>

--- a/Puppetlabs/Puppet.munki.recipe
+++ b/Puppetlabs/Puppet.munki.recipe
@@ -17,7 +17,7 @@ the default, 'latest'.</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>support/Puppet</string>
         <key>NAME</key>
-        <string>Puppet</string>
+        <string>puppet</string>
         <key>VERSION</key>
         <string>latest</string>
         <key>pkginfo</key>


### PR DESCRIPTION
Puppetlabs uses lowercase 'puppet', 'facter' and 'hiera' to refer to the products. Changed the Name variable to reflect this naming convention.
