### PR TITLE
Quick fix to cause PkgInfoCreator to succeed

### DIFF
--- a/VLC/VLC.pkg.recipe
+++ b/VLC/VLC.pkg.recipe
@@ -57,7 +57,7 @@
             <key>Arguments</key>
             <dict>
                 <key>template_path</key>
-                <string>%RECIPE_DIR%/PackageInfoTemplate</string>
+                <string>PackageInfoTemplate</string>
                 <key>infofile</key>
                 <string>%RECIPE_CACHE_DIR%/PackageInfo</string>
                 <key>pkgtype</key>


### PR DESCRIPTION
As mentioned in issue #33, this code addresses the pkg failure found when running the pkg recipe alone or as a parent.
