### PR TITLE
Add installcheck_script to check for "json" Gem

### DIFF
--- a/Puppetlabs/Puppet.munki.recipe
+++ b/Puppetlabs/Puppet.munki.recipe
@@ -37,6 +37,16 @@ the default, 'latest'.</string>
             </array>
             <key>unattended_install</key>
             <true/>
+            <key>installcheck_script</key>
+            <string>#!/usr/bin/ruby
+# Check that Ruby "json" gem is installed (abort to prevent install if not)
+abort_msg = "[Info] Munki installcheck script: Skipping installation of %NAME% (versions &gt;= 3.5 require 'json' gem which is not included on system ruby for OS X &lt; 10.9)"
+begin
+    require "json"
+rescue LoadError 
+    abort abort_msg
+end
+</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
- Added an installcheck_script that runs a simple ruby script to
  attempt loading the "json" gem. On error, it aborts (and returns 1
  preventing Munki install).
- This should, hopefully, help end users of the Puppet AutoPkg recipes who are deploying to versions of OS X < 10.9 avoid having Puppet break on those clients due to the missing "json" Gem.
