### PR TITLE
Patch 1

### DIFF
--- a/Mozilla/MozillaURLProvider.py
+++ b/Mozilla/MozillaURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for MozillaURLProvider class"""
 
+import os
 import re
 import urllib2
 
@@ -69,8 +70,8 @@ class MozillaURLProvider(Processor):
         # Construct download directory URL.
         release_dir = release.lower()
 
-        index_url = "/".join(
-            (base_url, product_name, "releases", release_dir, "mac", locale))
+        index_url = os.path.join(
+            base_url, product_name, "releases", release_dir, "mac", locale)
         #print >>sys.stderr, index_url
 
         # Read HTML index.
@@ -89,9 +90,9 @@ class MozillaURLProvider(Processor):
                 % (product_name, index_url))
 
         # Return URL.
-        return "/".join(
-            (base_url, product_name, "releases", release_dir, "mac", locale,
-             match.group("filename")))
+        return os.path.join(
+            base_url, product_name, "releases", release_dir, "mac", locale,
+            match.group("filename"))
 
     def main(self):
         """Provide a Mozilla download URL"""

--- a/Mozilla/MozillaURLProvider.py
+++ b/Mozilla/MozillaURLProvider.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 """See docstring for MozillaURLProvider class"""
 
-import os
 import re
 import urllib2
 
@@ -70,8 +69,8 @@ class MozillaURLProvider(Processor):
         # Construct download directory URL.
         release_dir = release.lower()
 
-        index_url = os.path.join(
-            base_url, product_name, "releases", release_dir, "mac", locale)
+        index_url = "/".join(
+            (base_url, product_name, "releases", release_dir, "mac", locale))
         #print >>sys.stderr, index_url
 
         # Read HTML index.
@@ -90,9 +89,9 @@ class MozillaURLProvider(Processor):
                 % (product_name, index_url))
 
         # Return URL.
-        return os.path.join(
-            base_url, product_name, "releases", release_dir, "mac", locale,
-            match.group("filename"))
+        return "/".join(
+            (base_url, product_name, "releases", release_dir, "mac", locale,
+            match.group("filename")))
 
     def main(self):
         """Provide a Mozilla download URL"""

--- a/Mozilla/MozillaURLProvider.py
+++ b/Mozilla/MozillaURLProvider.py
@@ -24,7 +24,7 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["MozillaURLProvider"]
 
 
-MOZ_BASE_URL = "http://ftp.mozilla.org/pub/mozilla.org/"
+MOZ_BASE_URL = "http://ftp.mozilla.org/pub/mozilla.org"
                #"firefox/releases")
 RE_DMG = re.compile(r'a[^>]* href="(?P<filename>[^"]+\.dmg)"')
 
@@ -91,7 +91,7 @@ class MozillaURLProvider(Processor):
         # Return URL.
         return "/".join(
             (base_url, product_name, "releases", release_dir, "mac", locale,
-            match.group("filename")))
+             match.group("filename")))
 
     def main(self):
         """Provide a Mozilla download URL"""


### PR DESCRIPTION
Before the URI was like:

```
$ autopkg run -v Firefox.munki.recipe
Processing Firefox.munki.recipe...
MozillaURLProvider
MozillaURLProvider: Found URL http://ftp.mozilla.org/pub/mozilla.org//firefox/releases/latest/mac/en-US/Firefox%2035.0.1.dmg
```

```
Found URL http://ftp.mozilla.org/pub/mozilla.org//firefox/releases/latest/mac/en-US/Firefox%2035.0.1.dmg
```

the change will avoid double slashes

```
autopkg run -v Firefox.munki.recipe
Processing Firefox.munki.recipe...
MozillaURLProvider
MozillaURLProvider: Found URL http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest/mac/en-US/Firefox%2035.0.1.dmg
```