### PR TITLE
Alternate URL for checking the latest Flash Player installer

### DIFF
--- a/AdobeFlashPlayer/AdobeFlashPlayer.download.recipe
+++ b/AdobeFlashPlayer/AdobeFlashPlayer.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://fpdownload2.macromedia.com/get/flashplayer/update/current/install/install_all_mac_pl_sgn.z</string>
+                <string>https://fpdownload.macromedia.com/pub/flashplayer/update/current/sau/11/install/install_all_mac_pl_sgn.z</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This version of the URL was extracted from "/Library/Application Support/Adobe/Flash Player Install Manager/fpsaud" which runs as a LaunchDaemon via "/Library/LaunchDaemons/com.adobe.fpsaud.plist". It was able to pull a more recent version of Flash Player than the System Preference panel itself could.

Kudos to Eric Holtam (eholtam) on Twitter for helping diagnose this one.