### PR TITLE
Munki 2 requires Snow Leopard. Mark minimum_os_version in the pkginfos.

### DIFF
--- a/munkitools/munkitools2.munki.recipe
+++ b/munkitools/munkitools2.munki.recipe
@@ -195,6 +195,8 @@ https://munkibuilds.org/munkitools2-latest.pkg
                     <string>%MUNKITOOLS_CORE_DESCRIPTION%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_CORE_DISPLAYNAME%</string>
+                    <key>minimum_os_version</key>
+                    <string>10.6.0</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_CORE_NAME%</string>
                     <key>requires</key>
@@ -225,6 +227,8 @@ https://munkibuilds.org/munkitools2-latest.pkg
                     <string>%MUNKITOOLS_ADMIN_DESCRIPTION%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_ADMIN_DISPLAYNAME%</string>
+                    <key>minimum_os_version</key>
+                    <string>10.6.0</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_ADMIN_NAME%</string>
                     <key>unattended_install</key>
@@ -255,6 +259,8 @@ https://munkibuilds.org/munkitools2-latest.pkg
                     <string>%MUNKITOOLS_APP_DESCRIPTION%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_APP_DISPLAYNAME%</string>
+                    <key>minimum_os_version</key>
+                    <string>10.6.0</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_APP_NAME%</string>
                     <key>requires</key>
@@ -286,6 +292,8 @@ https://munkibuilds.org/munkitools2-latest.pkg
                     <string>%MUNKITOOLS_LAUNCHD_DESCRIPTION%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_LAUNCHD_DISPLAYNAME%</string>
+                    <key>minimum_os_version</key>
+                    <string>10.6.0</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
                 </dict>


### PR DESCRIPTION
I know. You're going to laugh. But I have one environment where 10.5 machines are still serviced by Munki. Granted I should have had a conditional check OS versions for munki2, but had forgotten. In any case the minmum_os_version perhaps ought to be reflected correctly for Munki 2.