### PR TITLE
Use https for appcast URL.

### DIFF
--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Handbrake</string>
         <key>SU_FEED_URL</key>
-        <string>http://handbrake.fr/appcast.x86_64.xml</string>
+        <string>https://handbrake.fr/appcast.x86_64.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
While looking into why Handbrake.download.recipe was coming back with a 404, I saw that the Handbrake folks offer the Sparkle update over HTTPS. This pull request updates the recipe to use that URL. Note: this doesn't fix the underlying 404 issue which appears to be a result of the Handbrake folks having an invalid URL listed in http://handbrake.fr/appcast.x86_64.xml.