### PR TITLE
Added CodeSignatureVerifier to VLC.download.recipe

### DIFF
--- a/VLC/VLC.download.recipe
+++ b/VLC/VLC.download.recipe
@@ -42,6 +42,17 @@ version 2.1.0. For this reason, the appcast_url variable is now hardcoded in the
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/VLC.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "org.videolan.vlc" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "75GAHG3SZQ")</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/VLC/VLC.download.recipe
+++ b/VLC/VLC.download.recipe
@@ -17,7 +17,7 @@ version 2.1.0. For this reason, the appcast_url variable is now hardcoded in the
         <string>VLC</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.4.0</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
VLC 2.2.1 seems to be properly signed with a version 2 signature.