### PR TITLE
Adium appcast url now is https

### DIFF
--- a/Adium/Adium.download.recipe
+++ b/Adium/Adium.download.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>appcast_url</key>
-                <string>http://www.adium.im/sparkle/update.php</string>
+                <string>https://www.adium.im/sparkle/update.php</string>
                 <key>appcast_query_pairs</key>
                 <dict>
                     <key>generation</key>


### PR DESCRIPTION
Adium moved the sparkle url to https.

```sh
curl http://www.adium.im/sparkle/update.php?generation=2&type=release
[1] 1022
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://www.adium.im/sparkle/update.php?generation=2">here</a>.</p>
</body></html>
```