### PR TITLE
Update Adium.download.recipe for https requests

### DIFF
--- a/Adium/Adium.download.recipe
+++ b/Adium/Adium.download.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>appcast_url</key>
-                <string>http://www.adium.im/sparkle/update.php</string>
+                <string>https://www.adium.im/sparkle/update.php</string>
                 <key>appcast_query_pairs</key>
                 <dict>
                     <key>generation</key>


### PR DESCRIPTION
I'm getting a 301 response code for http requests and AutoPkg is not following the redirect.  Adding **https** provides a 200 response.

``` bash
curl -X "GET" "http://www.adium.im/sparkle/update.php?generation=2&type=release"

curl -X "GET" "https://www.adium.im/sparkle/update.php?generation=2&type=release"
```