### PR TITLE
Initial push of new puppet-agent w/Collection format - for real this time

### DIFF
--- a/Puppetlabs/Puppet-Agent.download.recipe
+++ b/Puppetlabs/Puppet-Agent.download.recipe
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest Puppet-Agent in the Collections format from
+downloads.puppetlabs.com/mac/PC1. Bundles vendored Ruby, Facter, Hiera, Augeas, Puppet and MCollective.
+
+OS VERSION can be overridden, or left to
+the default, '10.10'.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.download.puppet-agent</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Puppet-Agent</string>
+		<key>OS_VERSION</key>
+		<string>10.10</string>
+		<key>product_name</key>
+		<string>agent</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.4.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>get_os_version</key>
+				<string>%OS_VERSION%</string>
+			</dict>
+			<key>Processor</key>
+			<string>PuppetlabsProductsURLProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>puppetagent%OS_VERSION%.dmg</string>
+				<key>url</key>
+				<string>%url%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/*.pkg</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Puppetlabs/Puppet-Agent.download.recipe
+++ b/Puppetlabs/Puppet-Agent.download.recipe
@@ -16,8 +16,6 @@ the default, '10.10'.</string>
 		<string>Puppet-Agent</string>
 		<key>OS_VERSION</key>
 		<string>10.10</string>
-		<key>product_name</key>
-		<string>agent</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.1</string>
@@ -28,6 +26,8 @@ the default, '10.10'.</string>
 			<dict>
 				<key>get_os_version</key>
 				<string>%OS_VERSION%</string>
+				<key>product_name</key>
+				<string>agent</string>
 			</dict>
 			<key>Processor</key>
 			<string>PuppetlabsProductsURLProvider</string>

--- a/Puppetlabs/Puppet-Agent.munki.recipe
+++ b/Puppetlabs/Puppet-Agent.munki.recipe
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest PuppetAgent and imports into Munki.
+
+OS_VERSION can be overridden for the specific package, or left to the current
+latest OS. As some of the vendored contents (like ruby and libraries) are compiled
+specifically for each OS, we're setting the minimum and 'maximum_os_version' keys.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.munki.puppet-agent</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>support/Puppet</string>
+		<key>NAME</key>
+		<string>Puppet-Agent</string>
+		<key>OS_VERSION</key>
+		<string>10.10</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Puppet is a configuration management solution that allows you to define the state of your IT infrastructure, and then automatically enforces the desired state</string>
+			<key>display_name</key>
+			<string>Puppet Agent</string>
+			<key>name</key>
+			<string>PuppetAgent</string>
+			<key>minimum_os_version</key>
+			<string>%OS_VERSION%.0</string>
+			<key>maximum_os_version</key>
+			<string>%OS_VERSION%.99</string>
+			<key>developer</key>
+			<string>Puppetlabs</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.4.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.download.puppet-agent</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Trying this again... as per #90, puppetlabs has now made the agent one pkg for both opensource and commercial, and broken down the installers by version of OS X, starting with 10.9 and 10.10. This new 'collections'  format includes all dependencies(with libs compiled for the specific OS) that they vendor, including Ruby, Facter, Hiera, Augeas, Puppet and MCollective.