### PR TITLE
Change example for version-checking, new full URL path

### DIFF
--- a/Puppetlabs/PuppetlabsProductsURLProvider.py
+++ b/Puppetlabs/PuppetlabsProductsURLProvider.py
@@ -68,9 +68,9 @@ class PuppetlabsProductsURLProvider(Processor):
         prod = self.env["product_name"]
         if prod == 'agent':
             os_version = self.env.get("get_os_version", OS_VERSION)
-            version_re = r"\d+\.\d+\.\d+" # e.g.: puppet-agent-1.2.0-osx-10.9-x86_64.dmg
-            re_download = ("href=\"(puppet-agent-(%s)-osx-(%s)-x86_64.dmg)\"" % (version_re, os_version))
-            download_url += "/PC1"
+            version_re = r"\d+\.\d+\.\d+" # e.g.: 10.10/PC1/x86_64/puppet-agent-1.2.5-1.osx10.10.dmg
+            download_url += str('/' + os_version + "/PC1/x86_64")
+            re_download = ("href=\"(puppet-agent-(%s)-1.osx(%s).dmg)\"" % (version_re, os_version))
         else:
             # look for "product-1.2.3.dmg"
             # skip anything with a '-' following the version no. ('rc', etc.)


### PR DESCRIPTION
Since this URL pattern is mirror’d by the pm.puppetlabs one used when you look for puppetEnterprise downloads(even though they’re supposed to be the same) I get the impression it’s going to stick around for the time being. Would be nice to take into account the -1 in the URL, but not getting definitive answers about current or future URL changes so, gotta ship