### PR TITLE
Updated to match new base URL and absolute links.

### DIFF
--- a/Mozilla/MozillaURLProvider.py
+++ b/Mozilla/MozillaURLProvider.py
@@ -24,9 +24,9 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["MozillaURLProvider"]
 
 
-MOZ_BASE_URL = "http://ftp.mozilla.org/pub/mozilla.org"
+MOZ_BASE_URL = "https://ftp.mozilla.org/pub"
                #"firefox/releases")
-RE_DMG = re.compile(r'a[^>]* href="(?P<filename>[^"]+\.dmg)"')
+RE_DMG = re.compile(r'a[^>]* href="/.+/(?P<filename>[^"]+\.dmg)"')
 
 
 class MozillaURLProvider(Processor):
@@ -70,7 +70,7 @@ class MozillaURLProvider(Processor):
         release_dir = release.lower()
 
         index_url = "/".join(
-            (base_url, product_name, "releases", release_dir, "mac", locale))
+            (base_url, product_name, "releases", release_dir, "mac", locale, ""))
         #print >>sys.stderr, index_url
 
         # Read HTML index.
@@ -109,4 +109,3 @@ class MozillaURLProvider(Processor):
 if __name__ == "__main__":
     PROCESSOR = MozillaURLProvider()
     PROCESSOR.execute_shell()
-


### PR DESCRIPTION
Looks like Mozilla has changed their products' download URL structure, as the [old index page](https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest/mac/en-US/) now leads to a "Not Found" message for me.

I've tried to update MozillaURLProvider with the new changes. Does this look good?