### PR TITLE
Office 2016 Recipe Improvements

### DIFF
--- a/MSOfficeUpdates/MSExcel2016.download.recipe
+++ b/MSOfficeUpdates/MSExcel2016.download.recipe
@@ -47,7 +47,7 @@ VERSION currently only supports 'latest'.
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%-%version%.pkg</string>
+                <string>%NAME%.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/MSOfficeUpdates/MSExcel2016.munki.recipe
+++ b/MSOfficeUpdates/MSExcel2016.munki.recipe
@@ -40,6 +40,10 @@ VERSION currently only supports 'latest'.</string>
             </array>
             <key>name</key>
             <string>%NAME%</string>
+            <key>category</key>
+            <string>Productivity</string>
+            <key>developer</key>
+            <string>Microsoft</string>
             <key>unattended_install</key>
             <true/>
         </dict>

--- a/MSOfficeUpdates/MSOneNote2016.download.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.download.recipe
@@ -47,7 +47,7 @@ VERSION currently only supports 'latest'.
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%-%version%.pkg</string>
+                <string>%NAME%.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/MSOfficeUpdates/MSOneNote2016.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.munki.recipe
@@ -40,6 +40,10 @@ VERSION currently only supports 'latest'.</string>
             </array>
             <key>name</key>
             <string>%NAME%</string>
+            <key>category</key>
+            <string>Productivity</string>
+            <key>developer</key>
+            <string>Microsoft</string>
             <key>unattended_install</key>
             <true/>
         </dict>

--- a/MSOfficeUpdates/MSOutlook2016.download.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.download.recipe
@@ -47,7 +47,7 @@ VERSION currently only supports 'latest'.
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%-%version%.pkg</string>
+                <string>%NAME%.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/MSOfficeUpdates/MSOutlook2016.munki.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.munki.recipe
@@ -40,6 +40,10 @@ VERSION currently only supports 'latest'.</string>
             </array>
             <key>name</key>
             <string>%NAME%</string>
+            <key>category</key>
+            <string>Productivity</string>
+            <key>developer</key>
+            <string>Microsoft</string>            
             <key>unattended_install</key>
             <true/>
         </dict>

--- a/MSOfficeUpdates/MSPowerPoint2016.download.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.download.recipe
@@ -47,7 +47,7 @@ VERSION currently only supports 'latest'.
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%-%version%.pkg</string>
+                <string>%NAME%.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
@@ -40,6 +40,10 @@ VERSION currently only supports 'latest'.</string>
             </array>
             <key>name</key>
             <string>%NAME%</string>
+            <key>category</key>
+            <string>Productivity</string>
+            <key>developer</key>
+            <string>Microsoft</string>            
             <key>unattended_install</key>
             <true/>
         </dict>

--- a/MSOfficeUpdates/MSWord2016.download.recipe
+++ b/MSOfficeUpdates/MSWord2016.download.recipe
@@ -47,7 +47,7 @@ VERSION currently only supports 'latest'.
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%-%version%.pkg</string>
+                <string>%NAME%.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/MSOfficeUpdates/MSWord2016.munki.recipe
+++ b/MSOfficeUpdates/MSWord2016.munki.recipe
@@ -40,6 +40,10 @@ VERSION currently only supports 'latest'.</string>
             </array>
             <key>name</key>
             <string>%NAME%</string>
+            <key>category</key>
+            <string>Productivity</string>
+            <key>developer</key>
+            <string>Microsoft</string>            
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
Removed version from cache download filename, to stop Munki importing  packages with a redundant version in filename (e.g. MSWord2016-15.15.0-15.15.pkg).

Added category (Productivity) and developer (Microsoft) keys.