### PR TITLE
CodeSignatureVerifier and install recipe for OmniFocus2

### DIFF
--- a/OmniGroup/OmniFocus2.download.recipe
+++ b/OmniGroup/OmniFocus2.download.recipe
@@ -12,8 +12,22 @@
         <string>OmniFocus2</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.1</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.omnigroupproduct</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/OmniFocus.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and certificate leaf = H"26fe998f5ff3bad1beeac952a233231d4e5ad523" and identifier "com.omnigroup.OmniFocus2"</string>
+            </dict>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/OmniGroup/OmniFocus2.install.recipe
+++ b/OmniGroup/OmniFocus2.install.recipe
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads latest OmniFocus2 disk image and installs into /Applications.</string>
+    <key>Identifier</key>
+    <string>com.github.autopkg.install.omnifocus2</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>OmniFocus2</string>
+        <key>DESTINATION_PATH</key>
+        <string>/Applications/</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.6.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.autopkg.download.omnifocus2</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>InstallFromDMG</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%pathname%</string>
+                <key>items_to_copy</key>
+                <array>
+                    <dict>
+                        <key>source_item</key>
+                        <string>OmniFocus.app</string>
+                        <key>destination_path</key>
+                        <string>%DESTINATION_PATH%</string>
+                    </dict>
+                </array>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
CodeSignatureVerifier could've been added to the generic product download recipe but it would fail when downloading older Omni products.