### PR TITLE
Update appcast_url to new XQuartz SUFeedURL.

### DIFF
--- a/XQuartz/XQuartz.download.recipe
+++ b/XQuartz/XQuartz.download.recipe
@@ -26,7 +26,7 @@ Override BRANCH with either 'beta' or 'release' for the applicable Sparkle feed.
             <key>Arguments</key>
             <dict>
                 <key>appcast_url</key>
-                <string>https://xquartz.macosforge.org/downloads/sparkle/%BRANCH%.xml</string>
+                <string>https://www.xquartz.org/releases/sparkle/%BRANCH%.xml</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
XQuartz 2.7.9 is now available from https://www.xquartz.org/.

The new version includes a change to the SUFeedURL. The XQuartz.download recipe is therefore currently pointing to a feed URL that will presumably not be updated any more. This message in the x-11 mailing lists seems to confirm this:

http://lists.apple.com/archives/x11-users/2016/May/msg00022.html