### PR TITLE
https downloads for AdobeAIR and AdobeFlashPlayer

### DIFF
--- a/AdobeAIR/AdobeAIR.download.recipe
+++ b/AdobeAIR/AdobeAIR.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>AdobeAIR</string>
         <key>URL</key>
-        <string>http://airdownload.adobe.com/air/mac/download/latest/AdobeAIR.dmg</string>
+        <string>https://airdownload.adobe.com/air/mac/download/latest/AdobeAIR.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>

--- a/AdobeAIR/AdobeAIR.download.recipe
+++ b/AdobeAIR/AdobeAIR.download.recipe
@@ -14,7 +14,7 @@
         <string>https://airdownload.adobe.com/air/mac/download/latest/AdobeAIR.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.6.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/AdobeAIR/AdobeAIR.pkg.recipe
+++ b/AdobeAIR/AdobeAIR.pkg.recipe
@@ -15,7 +15,7 @@ Based on jamesz's work here: https://github.com/jamesez/automunki/tree/master/ad
         <string>http://airdownload.adobe.com/air/mac/download/latest/AdobeAIR.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.AdobeAIR</string>
     <key>Process</key>

--- a/AdobeAIR/AdobeAir.munki.recipe
+++ b/AdobeAIR/AdobeAir.munki.recipe
@@ -32,7 +32,7 @@ Based on jamesz's work here: https://github.com/jamesez/automunki/tree/master/ad
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.pkg.AdobeAIR</string>
     <key>Process</key>

--- a/AdobeFlashPlayer/AdobeFlashPlayer.download.recipe
+++ b/AdobeFlashPlayer/AdobeFlashPlayer.download.recipe
@@ -12,7 +12,7 @@
         <string>AdobeFlashPlayer</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>0.6.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/AdobeFlashPlayer/AdobeFlashPlayer.install.recipe
+++ b/AdobeFlashPlayer/AdobeFlashPlayer.install.recipe
@@ -12,7 +12,7 @@
         <string>AdobeFlashPlayer</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.FlashPlayer</string>
     <key>Process</key>

--- a/AdobeFlashPlayer/AdobeFlashPlayer.munki.recipe
+++ b/AdobeFlashPlayer/AdobeFlashPlayer.munki.recipe
@@ -31,7 +31,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.FlashPlayer</string>
     <key>Process</key>

--- a/AdobeFlashPlayer/AdobeFlashPlayer.pkg.recipe
+++ b/AdobeFlashPlayer/AdobeFlashPlayer.pkg.recipe
@@ -12,7 +12,7 @@
         <string>AdobeFlashPlayer</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.FlashPlayer</string>
     <key>Process</key>

--- a/AdobeFlashPlayer/AdobeFlashURLProvider.py
+++ b/AdobeFlashPlayer/AdobeFlashURLProvider.py
@@ -27,7 +27,7 @@ __all__ = ["AdobeFlashURLProvider"]
 UPDATE_XML_URL = ("http://fpdownload2.macromedia.com/"
                   "get/flashplayer/update/current/xml/version_en_mac_pl.xml")
 
-DOWNLOAD_TEMPLATE_URL = ("http://fpdownload.macromedia.com/"
+DOWNLOAD_TEMPLATE_URL = ("https://fpdownload.macromedia.com/"
                          "get/flashplayer/pdc/%s/install_flash_player_osx.dmg")
 
 class AdobeFlashURLProvider(Processor):


### PR DESCRIPTION
This small change secures the download links for AdobeAIR and AdobeFlashPlayer.

While the Update XML URL for AdobeFlashPlayer can point to https, it appears that in some cases can be an untrusted connection due to an invalid Akamai configuration (net::ERR_CERT_COMMON_NAME_INVALID)