### PR TITLE
MSOffice2011 Redirect xml download url to https

### DIFF
--- a/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
@@ -20,6 +20,7 @@ import urllib2
 
 from distutils.version import LooseVersion
 from operator import itemgetter
+from urlparse import urlparse, urlunparse
 
 from autopkglib import Processor, ProcessorError
 
@@ -231,7 +232,14 @@ class MSOffice2011UpdateInfoProvider(Processor):
                                                for item in metadata])))
             item = matched_items[0]
 
-        self.env["url"] = item["Location"]
+        # Try to use https even though url is http
+        try:
+            pkg_url = item["Location"]
+            https_url = list(urlparse(pkg_url))
+            https_url[0] = 'https'
+            self.env["url"] = urlunparse(https_url)
+        except ValueError:
+            self.env["url"] = item["Location"]
         self.env["pkg_name"] = item["Payload"]
         self.env["version"] = self.get_version(item)
         self.output("Found URL %s" % self.env["url"])

--- a/MSOfficeUpdates/MSOffice2011Updates.download.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.download.recipe
@@ -19,7 +19,7 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
         <string>0409</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
@@ -69,7 +69,7 @@ certificate for the downloaded update can still be manually verified, however.
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.Office2011Updates</string>
     <key>Process</key>

--- a/MSOfficeUpdates/MSOffice2011Updates.pkg.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.pkg.recipe
@@ -19,7 +19,7 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
         <string>0409</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.Office2011Updates</string>
     <key>Process</key>


### PR DESCRIPTION
This PR parses the XML download links and then replaced http:// with https://. Unfortunately the xml file is not hosted on a secure repo.