### PR TITLE
MSOffice2011 Redirect xml download url to https

### DIFF
--- a/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
@@ -43,7 +43,7 @@ __all__ = ["MSOffice2011UpdateInfoProvider"]
 CULTURE_CODE = "0409"
 BASE_URL = "http://www.microsoft.com/mac/autoupdate/%sMSOf14.xml"
 MUNKI_UPDATE_NAME = "Office2011_update"
-URL_DL = "http"
+DOWNLOAD_URL_SCHEME = "http"
 
 class MSOffice2011UpdateInfoProvider(Processor):
     """Provides a download URL for an Office 2011 update."""
@@ -64,11 +64,11 @@ class MSOffice2011UpdateInfoProvider(Processor):
                 "Default is %s. If this is given, culture_code is ignored."
                 % (BASE_URL % CULTURE_CODE)),
         },
-        "url_dl": {
+        "download_url_scheme": {
             "required": False,
             "description": (
-                "Use undocumented HTTPS download url. Defaults to '%s'"
-                % URL_DL),
+                "A value of https will use an undocumented download. Defaults to '%s'"
+                % DOWNLOAD_URL_SCHEME),
         },
         "version": {
             "required": False,
@@ -240,7 +240,7 @@ class MSOffice2011UpdateInfoProvider(Processor):
             item = matched_items[0]
 
         # Try to use https even though url is http
-        url_dl = self.env.get("url_dl", URL_DL)
+        download_url_scheme = self.env.get("download_url_scheme", DOWNLOAD_URL_SCHEME)
         if url_dl == "https":
         	try:
         		pkg_url = item["Location"]

--- a/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
@@ -20,6 +20,7 @@ import urllib2
 
 from distutils.version import LooseVersion
 from operator import itemgetter
+from urlparse import urlparse, urlunparse
 
 from autopkglib import Processor, ProcessorError
 
@@ -231,7 +232,14 @@ class MSOffice2011UpdateInfoProvider(Processor):
                                                for item in metadata])))
             item = matched_items[0]
 
-        self.env["url"] = item["Location"]
+        # Try to use https even though url is http
+        try:
+            pkg_url = item["Location"]
+            https_url = list(urlparse(pkg_url))
+            https_url[0] = 'https'
+            self.env["url"] = urlunparse(https_url)
+        except ValueError:
+            self.env["url"] = item["Location"]
         self.env["pkg_name"] = item["Payload"]
         self.env["version"] = self.get_version(item)
         self.output("Found URL %s" % self.env["url"])

--- a/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
@@ -241,7 +241,7 @@ class MSOffice2011UpdateInfoProvider(Processor):
 
         # Try to use https even though url is http
         download_url_scheme = self.env.get("download_url_scheme", DOWNLOAD_URL_SCHEME)
-        if url_dl == "https":
+        if DOWNLOAD_URL_SCHEME == "https":
         	try:
         		pkg_url = item["Location"]
         		https_url = list(urlparse(pkg_url))

--- a/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOffice2011UpdateInfoProvider.py
@@ -41,9 +41,9 @@ __all__ = ["MSOffice2011UpdateInfoProvider"]
 # See http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx
 # for a table of "Culture Codes"
 CULTURE_CODE = "0409"
-BASE_URL = "http://www.microsoft.com/mac/autoupdate/%sMSOf14.xml"
 MUNKI_UPDATE_NAME = "Office2011_update"
 DOWNLOAD_URL_SCHEME = "http"
+BASE_URL = DOWNLOAD_URL_SCHEME + "://www.microsoft.com/mac/autoupdate/%sMSOf14.xml"
 
 class MSOffice2011UpdateInfoProvider(Processor):
     """Provides a download URL for an Office 2011 update."""

--- a/MSOfficeUpdates/MSOffice2011Updates.download.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.download.recipe
@@ -8,7 +8,7 @@ Set VERSION to a specific version number to download that version instead.
 Set CULTURE_CODE to a different value to get a different localization. See
 http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Culture Codes.
 
-If you would like to use an undocumented HTTPS download, set URL_DL to https.
+If you would like to use an undocumented HTTPS download, set DOWNLOAD_URL_SCHEME to https.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.Office2011Updates</string>
@@ -20,7 +20,7 @@ If you would like to use an undocumented HTTPS download, set URL_DL to https.
         <string>latest</string>
         <key>CULTURE_CODE</key>
         <string>0409</string>
-        <key>URL_DL</key>
+        <key>DOWNLOAD_URL_SCHEME</key>
         <string>http</string>
     </dict>
     <key>MinimumVersion</key>

--- a/MSOfficeUpdates/MSOffice2011Updates.download.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.download.recipe
@@ -6,7 +6,10 @@
     <string>Finds latest Office 2011 update and downloads the disk image.
 Set VERSION to a specific version number to download that version instead.
 Set CULTURE_CODE to a different value to get a different localization. See
-http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Culture Codes.</string>
+http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Culture Codes.
+
+If you would like to use an undocumented HTTPS download, set URL_DL to https.
+</string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.Office2011Updates</string>
     <key>Input</key>
@@ -17,6 +20,8 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
         <string>latest</string>
         <key>CULTURE_CODE</key>
         <string>0409</string>
+        <key>URL_DL</key>
+        <string>http</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.0</string>

--- a/MSOfficeUpdates/MSOffice2011Updates.download.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.download.recipe
@@ -19,7 +19,7 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
         <string>0409</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
@@ -8,7 +8,7 @@ Set VERSION to a specific version number to download that version instead.
 Set CULTURE_CODE to a different value to get a different localization. See
 http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Culture Codes.
 
-If you would like to use an undocumented HTTPS download, set URL_DL to https.
+If you would like to use an undocumented HTTPS download, set DOWNLOAD_URL_SCHEME to https.
 
 `autopkg run MSOffice2011Updates.munki -k VERSION=14.1.0 -k DISABLE_CODE_SIGNATURE_VERIFICATION=true`
 will download and import the 14.1.0 update; most of the later Office updates declare they require
@@ -30,7 +30,7 @@ certificate for the downloaded update can still be manually verified, however.
         <string>latest</string>
         <key>CULTURE_CODE</key>
         <string>0409</string>
-        <key>URL_DL</key>
+        <key>DOWNLOAD_URL_SCHEME</key>
         <string>http</string>
         <key>pkginfo</key>
         <dict>

--- a/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
@@ -8,6 +8,8 @@ Set VERSION to a specific version number to download that version instead.
 Set CULTURE_CODE to a different value to get a different localization. See
 http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Culture Codes.
 
+If you would like to use an undocumented HTTPS download, set URL_DL to https.
+
 `autopkg run MSOffice2011Updates.munki -k VERSION=14.1.0 -k DISABLE_CODE_SIGNATURE_VERIFICATION=true`
 will download and import the 14.1.0 update; most of the later Office updates declare they require
 this update, so save yourself some headaches by adding this update to your repo even if you don't
@@ -28,6 +30,8 @@ certificate for the downloaded update can still be manually verified, however.
         <string>latest</string>
         <key>CULTURE_CODE</key>
         <string>0409</string>
+        <key>URL_DL</key>
+        <string>http</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>

--- a/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
@@ -69,7 +69,7 @@ certificate for the downloaded update can still be manually verified, however.
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.Office2011Updates</string>
     <key>Process</key>

--- a/MSOfficeUpdates/MSOffice2011Updates.pkg.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.pkg.recipe
@@ -6,7 +6,10 @@
     <string>Finds latest Office 2011 update, downloads the disk image and extracts the pkg.
 Set VERSION to a specific version number to download that version instead.
 Set CULTURE_CODE to a different value to get a different localization. See
-http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Culture Codes.</string>
+http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Culture Codes.
+
+If you would like to use an undocumented HTTPS download, set URL_DL to https.
+</string>
     <key>Identifier</key>
     <string>com.github.autopkg.pkg.Office2011Updates</string>
     <key>Input</key>
@@ -17,6 +20,8 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
         <string>latest</string>
         <key>CULTURE_CODE</key>
         <string>0409</string>
+        <key>URL_DL</key>
+        <string>http</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.0</string>

--- a/MSOfficeUpdates/MSOffice2011Updates.pkg.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.pkg.recipe
@@ -8,7 +8,7 @@ Set VERSION to a specific version number to download that version instead.
 Set CULTURE_CODE to a different value to get a different localization. See
 http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Culture Codes.
 
-If you would like to use an undocumented HTTPS download, set URL_DL to https.
+If you would like to use an undocumented HTTPS download, set DOWNLOAD_URL_SCHEME to https.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.pkg.Office2011Updates</string>
@@ -20,7 +20,7 @@ If you would like to use an undocumented HTTPS download, set URL_DL to https.
         <string>latest</string>
         <key>CULTURE_CODE</key>
         <string>0409</string>
-        <key>URL_DL</key>
+        <key>DOWNLOAD_URL_SCHEME</key>
         <string>http</string>
     </dict>
     <key>MinimumVersion</key>

--- a/MSOfficeUpdates/MSOffice2011Updates.pkg.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.pkg.recipe
@@ -19,7 +19,7 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
         <string>0409</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.Office2011Updates</string>
     <key>Process</key>


### PR DESCRIPTION
This PR parses the XML download links and then replaced http:// with https://. Unfortunately the xml file is not hosted on a secure repo.