### PR TITLE
munkitools2 - Support for Category/Developer/Icon

### DIFF
--- a/munkitools/munkitools2-autobuild.munki.recipe
+++ b/munkitools/munkitools2-autobuild.munki.recipe
@@ -30,7 +30,7 @@ MUNKI_ICON should be overridden with your icon name.
         <key>MUNKI_DEVELOPER</key>
         <string>The Munki Project</string>
         <key>MUNKI_ICON</key>
-        <string>munkitools.png</string>
+        <string></string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>munkitools</string>
         <!--  -->

--- a/munkitools/munkitools2-autobuild.munki.recipe
+++ b/munkitools/munkitools2-autobuild.munki.recipe
@@ -18,6 +18,12 @@ https://munkibuilds.org/2.2.2.2416/munkitools-2.2.2.2416.pkg</string>
         <string>munkitools2</string>
         <key>MUNKI_CATALOG</key>
         <string>development</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>munkitools</string>
+        <key>MUNKI_DEVELOPER</key>
+        <string>Greg Neagle</string>
+        <key>MUNKI_ICON</key>
+        <string>munkitools.png</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>munkitools</string>
         <!--  -->
@@ -183,10 +189,16 @@ https://munkibuilds.org/2.2.2.2416/munkitools-2.2.2.2416.pkg</string>
                     <array>
                         <string>%MUNKI_CATALOG%</string>
                     </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
                     <key>description</key>
                     <string>%MUNKITOOLS_CORE_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_CORE_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
                     <string>10.6.0</string>
                     <key>name</key>
@@ -215,10 +227,16 @@ https://munkibuilds.org/2.2.2.2416/munkitools-2.2.2.2416.pkg</string>
                     <array>
                         <string>%MUNKI_CATALOG%</string>
                     </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
                     <key>description</key>
                     <string>%MUNKITOOLS_ADMIN_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_ADMIN_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
                     <string>10.6.0</string>
                     <key>name</key>
@@ -247,10 +265,16 @@ https://munkibuilds.org/2.2.2.2416/munkitools-2.2.2.2416.pkg</string>
                     <array>
                         <string>%MUNKI_CATALOG%</string>
                     </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
                     <key>description</key>
                     <string>%MUNKITOOLS_APP_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_APP_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
                     <string>10.6.0</string>
                     <key>name</key>
@@ -280,10 +304,16 @@ https://munkibuilds.org/2.2.2.2416/munkitools-2.2.2.2416.pkg</string>
                     <array>
                         <string>%MUNKI_CATALOG%</string>
                     </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
                     <key>description</key>
                     <string>%MUNKITOOLS_LAUNCHD_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_LAUNCHD_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
                     <string>10.6.0</string>
                     <key>name</key>

--- a/munkitools/munkitools2-autobuild.munki.recipe
+++ b/munkitools/munkitools2-autobuild.munki.recipe
@@ -7,7 +7,10 @@
 https://munkibuilds.org. DOWNLOAD_URL can be overridden to
 an alternate URL, from either your own server or an alternate
 package version, ie.
-https://munkibuilds.org/2.2.2.2416/munkitools-2.2.2.2416.pkg</string>
+https://munkibuilds.org/2.2.2.2416/munkitools-2.2.2.2416.pkg
+
+MUNKI_ICON should be overridden with your icon name.
+		</string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.munkitools2-autobuild</string>
     <key>Input</key>

--- a/munkitools/munkitools2-autobuild.munki.recipe
+++ b/munkitools/munkitools2-autobuild.munki.recipe
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads and imports a pre-built Munki 2 from
+    <string>Note: munkitools does not include a code signature. If your
+organization requires code signature, it is recommend to internally sign
+the application.
+
+Downloads and imports a pre-built Munki 2 from
 https://munkibuilds.org. DOWNLOAD_URL can be overridden to
 an alternate URL, from either your own server or an alternate
 package version, ie.

--- a/munkitools/munkitools2-autobuild.munki.recipe
+++ b/munkitools/munkitools2-autobuild.munki.recipe
@@ -21,7 +21,7 @@ https://munkibuilds.org/2.2.2.2416/munkitools-2.2.2.2416.pkg</string>
         <key>MUNKI_CATEGORY</key>
         <string>munkitools</string>
         <key>MUNKI_DEVELOPER</key>
-        <string>Greg Neagle</string>
+        <string>The Munki Project</string>
         <key>MUNKI_ICON</key>
         <string>munkitools.png</string>
         <key>MUNKI_REPO_SUBDIR</key>

--- a/munkitools/munkitools2.munki.recipe
+++ b/munkitools/munkitools2.munki.recipe
@@ -19,7 +19,10 @@ existing override for use with the autobuild recipe.
 The GitHubReleasesInfoProvider processor used by this recipe also
 respects an input variable: 'sort_by_highest_tag_names', which
 if set, will ignore the post dates of the releases and instead sort
-descending by tag names according to LooseVersion semantics.</string>
+descending by tag names according to LooseVersion semantics.
+
+MUNKI_ICON should be overridden with your icon name.
+</string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.munkitools2</string>
     <key>Input</key>

--- a/munkitools/munkitools2.munki.recipe
+++ b/munkitools/munkitools2.munki.recipe
@@ -33,7 +33,7 @@ descending by tag names according to LooseVersion semantics.</string>
         <key>MUNKI_CATEGORY</key>
         <string>munkitools</string>
         <key>MUNKI_DEVELOPER</key>
-        <string>Greg Neagle</string>
+        <string>The Munki Project</string>
         <key>MUNKI_ICON</key>
         <string>munkitools.png</string>
         <key>MUNKI_REPO_SUBDIR</key>

--- a/munkitools/munkitools2.munki.recipe
+++ b/munkitools/munkitools2.munki.recipe
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads and imports version 2 of the Munki tools via
+    <string>Note: munkitools does not include a code signature. If your
+organization requires code signature, it is recommend to internally sign
+the application.
+    
+Downloads and imports version 2 of the Munki tools via
 the official releases listing on GitHub.
 
 By default only "final" releases are included. Set INCLUDE_PRERELEASES

--- a/munkitools/munkitools2.munki.recipe
+++ b/munkitools/munkitools2.munki.recipe
@@ -30,6 +30,12 @@ descending by tag names according to LooseVersion semantics.</string>
         <string>munkitools2</string>
         <key>MUNKI_CATALOG</key>
         <string>development</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>munkitools</string>
+        <key>MUNKI_DEVELOPER</key>
+        <string>Greg Neagle</string>
+        <key>MUNKI_ICON</key>
+        <string>munkitools.png</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>munkitools</string>
         <!--  -->
@@ -203,10 +209,16 @@ descending by tag names according to LooseVersion semantics.</string>
                     <array>
                         <string>%MUNKI_CATALOG%</string>
                     </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
                     <key>description</key>
                     <string>%MUNKITOOLS_CORE_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_CORE_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
                     <string>10.6.0</string>
                     <key>name</key>
@@ -235,10 +247,16 @@ descending by tag names according to LooseVersion semantics.</string>
                     <array>
                         <string>%MUNKI_CATALOG%</string>
                     </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
                     <key>description</key>
                     <string>%MUNKITOOLS_ADMIN_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_ADMIN_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
                     <string>10.6.0</string>
                     <key>name</key>
@@ -267,10 +285,16 @@ descending by tag names according to LooseVersion semantics.</string>
                     <array>
                         <string>%MUNKI_CATALOG%</string>
                     </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
                     <key>description</key>
                     <string>%MUNKITOOLS_APP_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_APP_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
                     <string>10.6.0</string>
                     <key>name</key>
@@ -300,10 +324,16 @@ descending by tag names according to LooseVersion semantics.</string>
                     <array>
                         <string>%MUNKI_CATALOG%</string>
                     </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
                     <key>description</key>
                     <string>%MUNKITOOLS_LAUNCHD_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
                     <key>display_name</key>
                     <string>%MUNKITOOLS_LAUNCHD_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
                     <string>10.6.0</string>
                     <key>name</key>

--- a/munkitools/munkitools2.munki.recipe
+++ b/munkitools/munkitools2.munki.recipe
@@ -6,7 +6,7 @@
     <string>Note: munkitools does not include a code signature. If your
 organization requires code signature, it is recommend to internally sign
 the application.
-    
+
 Downloads and imports version 2 of the Munki tools via
 the official releases listing on GitHub.
 
@@ -42,7 +42,7 @@ MUNKI_ICON should be overridden with your icon name.
         <key>MUNKI_DEVELOPER</key>
         <string>The Munki Project</string>
         <key>MUNKI_ICON</key>
-        <string>munkitools.png</string>
+        <string></string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>munkitools</string>
         <!--  -->


### PR DESCRIPTION
This brings the munkitools2 recipe in line with the common pkginfo an administrator would set/override.