### PR TITLE
TextMate2 - API HTTPS call

### DIFF
--- a/TextMate/TextMate2.download.recipe
+++ b/TextMate/TextMate2.download.recipe
@@ -19,7 +19,7 @@ preferences panel.
         <string>release</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.6.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/TextMate/TextMate2.munki.recipe
+++ b/TextMate/TextMate2.munki.recipe
@@ -49,7 +49,7 @@ preferences panel.
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.6.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.TextMate2</string>
     <key>Process</key>

--- a/TextMate/TextMateURLProvider.py
+++ b/TextMate/TextMateURLProvider.py
@@ -19,7 +19,7 @@ from subprocess import Popen, PIPE
 from autopkglib import Processor, ProcessorError
 
 DEFAULT_BRANCH = "release"
-BASE_URL = "http://api.textmate.org/downloads/"
+BASE_URL = "https://api.textmate.org/downloads/"
 
 # Another interesting URL that returns an ASCII-style plist used by
 # the app's own SU mechanism, but the download URL it returns is an


### PR DESCRIPTION
This small change moves the API call to HTTPS (the download itself is already using a https CDN).