### PR TITLE
Note about code sig ver for Handbrake

### DIFF
--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -3,7 +3,8 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest Handbrake disk image.</string>
+    <string>Downloads the latest Handbrake disk image.
+    Note: The code signature verification for Handbrake cannot be done at this time.</string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.Handbrake</string>
     <key>Input</key>


### PR DESCRIPTION
```codesign --display -r- --deep -v /Applications/HandBrake.app 
/Applications/HandBrake.app: code object is not signed at all```

So code signature verification isn't possible for HandBrake right now.