### PR TITLE
Office2016: Support for new CDN used by MAU 3.6.0

### DIFF
--- a/MSOfficeUpdates/MSExcel2016.download.recipe
+++ b/MSOfficeUpdates/MSExcel2016.download.recipe
@@ -6,6 +6,12 @@
     <string>Downloads the latest Excel 2016 multilingual update pkg,
 and appends the version to the end of the filename.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -24,6 +30,8 @@ used by other processors in a child recipe.
     <string>0.4.2</string>
     <key>Input</key>
     <dict>
+        <key>CHANNEL</key>
+        <string>Production</string>
         <key>LOCALE_ID</key>
         <string>1033</string>
         <key>NAME</key>
@@ -38,6 +46,8 @@ used by other processors in a child recipe.
             <string>MSOffice2016URLandUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>
+                <key>channel</key>
+                <string>%CHANNEL%</string>
                 <key>locale_id</key>
                 <string>%LOCALE_ID%</string>
                 <key>product</key>

--- a/MSOfficeUpdates/MSExcel2016.munki.recipe
+++ b/MSOfficeUpdates/MSExcel2016.munki.recipe
@@ -61,6 +61,8 @@ installcheck_script).</string>
             <array>
                 <string>testing</string>
             </array>
+            <key>display_name</key>
+            <string>Microsoft Excel for Mac</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>

--- a/MSOfficeUpdates/MSExcel2016.munki.recipe
+++ b/MSOfficeUpdates/MSExcel2016.munki.recipe
@@ -10,6 +10,12 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -78,6 +84,8 @@ installcheck_script).</string>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>

--- a/MSOfficeUpdates/MSOneNote2016.download.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.download.recipe
@@ -6,6 +6,12 @@
     <string>Downloads the latest OneNote 2016 multilingual update pkg,
 and appends the version to the end of the filename.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -24,6 +30,8 @@ used by other processors in a child recipe.
     <string>0.4.2</string>
     <key>Input</key>
     <dict>
+        <key>CHANNEL</key>
+        <string>Production</string>
         <key>LOCALE_ID</key>
         <string>1033</string>
         <key>NAME</key>
@@ -38,6 +46,8 @@ used by other processors in a child recipe.
             <string>MSOffice2016URLandUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>
+                <key>channel</key>
+                <string>%CHANNEL%</string>
                 <key>locale_id</key>
                 <string>%LOCALE_ID%</string>
                 <key>product</key>

--- a/MSOfficeUpdates/MSOneNote2016.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.munki.recipe
@@ -61,6 +61,8 @@ installcheck_script).</string>
             <array>
                 <string>testing</string>
             </array>
+            <key>display_name</key>
+            <string>Microsoft OneNote for Mac</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>

--- a/MSOfficeUpdates/MSOneNote2016.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.munki.recipe
@@ -10,6 +10,12 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -78,6 +84,8 @@ installcheck_script).</string>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>

--- a/MSOfficeUpdates/MSOutlook2016.download.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.download.recipe
@@ -6,6 +6,12 @@
     <string>Downloads the latest Outlook 2016 multilingual update pkg,
 and appends the version to the end of the filename.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -24,6 +30,8 @@ used by other processors in a child recipe.
     <string>0.4.2</string>
     <key>Input</key>
     <dict>
+        <key>CHANNEL</key>
+        <string>Production</string>
         <key>LOCALE_ID</key>
         <string>1033</string>
         <key>NAME</key>
@@ -38,6 +46,8 @@ used by other processors in a child recipe.
             <string>MSOffice2016URLandUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>
+                <key>channel</key>
+                <string>%CHANNEL%</string>
                 <key>locale_id</key>
                 <string>%LOCALE_ID%</string>
                 <key>product</key>

--- a/MSOfficeUpdates/MSOutlook2016.munki.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.munki.recipe
@@ -61,6 +61,8 @@ installcheck_script).</string>
             <array>
                 <string>testing</string>
             </array>
+            <key>display_name</key>
+            <string>Microsoft Outlook for Mac</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>

--- a/MSOfficeUpdates/MSOutlook2016.munki.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.munki.recipe
@@ -10,6 +10,12 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -78,6 +84,8 @@ installcheck_script).</string>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>

--- a/MSOfficeUpdates/MSPowerPoint2016.download.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.download.recipe
@@ -6,6 +6,12 @@
     <string>Downloads the latest PowerPoint 2016 multilingual update pkg,
 and appends the version to the end of the filename.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -24,6 +30,8 @@ used by other processors in a child recipe.
     <string>0.4.2</string>
     <key>Input</key>
     <dict>
+        <key>CHANNEL</key>
+        <string>Production</string>
         <key>LOCALE_ID</key>
         <string>1033</string>
         <key>NAME</key>
@@ -38,6 +46,8 @@ used by other processors in a child recipe.
             <string>MSOffice2016URLandUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>
+                <key>channel</key>
+                <string>%CHANNEL%</string>
                 <key>locale_id</key>
                 <string>%LOCALE_ID%</string>
                 <key>product</key>

--- a/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
@@ -61,6 +61,8 @@ installcheck_script).</string>
             <array>
                 <string>testing</string>
             </array>
+            <key>display_name</key>
+            <string>Microsoft PowerPoint for Mac</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>

--- a/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
@@ -10,6 +10,12 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -78,6 +84,8 @@ installcheck_script).</string>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>

--- a/MSOfficeUpdates/MSWord2016.download.recipe
+++ b/MSOfficeUpdates/MSWord2016.download.recipe
@@ -6,6 +6,12 @@
     <string>Downloads the latest Word 2016 multilingual update pkg,
 and appends the version to the end of the filename.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -24,6 +30,8 @@ used by other processors in a child recipe.
     <string>0.4.2</string>
     <key>Input</key>
     <dict>
+        <key>CHANNEL</key>
+        <string>Production</string>
         <key>LOCALE_ID</key>
         <string>1033</string>
         <key>NAME</key>
@@ -38,6 +46,8 @@ used by other processors in a child recipe.
             <string>MSOffice2016URLandUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>
+                <key>channel</key>
+                <string>%CHANNEL%</string>
                 <key>locale_id</key>
                 <string>%LOCALE_ID%</string>
                 <key>product</key>

--- a/MSOfficeUpdates/MSWord2016.munki.recipe
+++ b/MSOfficeUpdates/MSWord2016.munki.recipe
@@ -61,6 +61,8 @@ installcheck_script).</string>
             <array>
                 <string>testing</string>
             </array>
+            <key>display_name</key>
+            <string>Microsoft Word for Mac</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>

--- a/MSOfficeUpdates/MSWord2016.munki.recipe
+++ b/MSOfficeUpdates/MSWord2016.munki.recipe
@@ -10,6 +10,12 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
@@ -78,6 +84,8 @@ installcheck_script).</string>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>


### PR DESCRIPTION
Opening this one here if anyone has any opinions on the choices I've made here for all of the changes described in the commit:

- adds a `CHANNEL` input variable to download recipes, which allows fetching more bleeding-edge Insider builds
- updated User-Agent to match current MAU version
- use CFBundleVersion only in synthesized app installs items for Munki recipes, so that insider builds can be properly distinguished as newer
- use new-ish `Update Version` key supported in feeds rather than parsing it from `Title`