### PR TITLE
Fix CodeSignatureVerifier

### DIFF
--- a/Silverlight/Silverlight.download.recipe
+++ b/Silverlight/Silverlight.download.recipe
@@ -48,7 +48,7 @@
             <string>%pathname%/silverlight*.*pkg</string>
             <key>expected_authority_names</key>
             <array>
-              <string>Developer ID Installer: Microsoft Corporation</string>
+              <string>Developer ID Installer: Microsoft Corporation (UBF8T346G9)</string>
               <string>Developer ID Certification Authority</string>
               <string>Apple Root CA</string>
             </array>


### PR DESCRIPTION
Silverlight 5.1.50709.0 seems to have a new signature.  I verified this fix with my local copy of the .download recipe, and it worked OK.

Mike