### PR TITLE
Remove unnecessary download URL overrides

### DIFF
--- a/AdobeAIR/AdobeAIR.pkg.recipe
+++ b/AdobeAIR/AdobeAIR.pkg.recipe
@@ -11,8 +11,6 @@ Based on jamesz's work here: https://github.com/jamesez/automunki/tree/master/ad
     <dict>
         <key>NAME</key>
         <string>AdobeAIR</string>
-        <key>URL</key>
-        <string>http://airdownload.adobe.com/air/mac/download/latest/AdobeAIR.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.0</string>

--- a/AdobeAIR/AdobeAir.munki.recipe
+++ b/AdobeAIR/AdobeAir.munki.recipe
@@ -11,8 +11,6 @@ Based on jamesz's work here: https://github.com/jamesez/automunki/tree/master/ad
     <dict>
         <key>NAME</key>
         <string>AdobeAIR</string>
-        <key>URL</key>
-        <string>http://airdownload.adobe.com/air/mac/download/latest/AdobeAIR.dmg</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/adobe</string>
         <key>pkginfo</key>

--- a/GoogleChrome/GoogleChrome.install.recipe
+++ b/GoogleChrome/GoogleChrome.install.recipe
@@ -7,10 +7,7 @@
     <key>Identifier</key>
     <string>com.github.autopkg.install.googlechrome</string>
     <key>Input</key>
-    <dict>
-        <key>DOWNLOAD_URL</key>
-        <string>https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg</string>
-    </dict>
+    <dict/>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
     <key>ParentRecipe</key>

--- a/Silverlight/Silverlight.install.recipe
+++ b/Silverlight/Silverlight.install.recipe
@@ -7,12 +7,7 @@
     <key>Identifier</key>
     <string>com.github.autopkg.install.Silverlight</string>
     <key>Input</key>
-    <dict>
-        <key>DOWNLOAD_URL</key>
-        <string>http://www.microsoft.com/getsilverlight/handlers/getsilverlight.ashx</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
-    </dict>
+    <dict/>
     <key>MinimumVersion</key>
     <string>0.6.0</string>
     <key>ParentRecipe</key>

--- a/Silverlight/Silverlight.munki.recipe
+++ b/Silverlight/Silverlight.munki.recipe
@@ -12,10 +12,6 @@
         <string>Silverlight</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://www.microsoft.com/getsilverlight/handlers/getsilverlight.ashx</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>

--- a/Skype/Skype.install.recipe
+++ b/Skype/Skype.install.recipe
@@ -7,10 +7,7 @@
     <key>Identifier</key>
     <string>com.github.autopkg.install.Skype</string>
     <key>Input</key>
-    <dict>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
-    </dict>
+    <dict/>
     <key>MinimumVersion</key>
     <string>0.6.0</string>
     <key>ParentRecipe</key>

--- a/Skype/Skype.install.recipe
+++ b/Skype/Skype.install.recipe
@@ -8,8 +8,6 @@
     <string>com.github.autopkg.install.Skype</string>
     <key>Input</key>
     <dict>
-        <key>DOWNLOAD_URL</key>
-        <string>http://www.skype.com/go/getskype-macosx.dmg</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>


### PR DESCRIPTION
Inherits URL from download recipe, which uses HTTPS instead of HTTP