### PR TITLE
Update Dropbox.munki.recipe

### DIFF
--- a/Dropbox/Dropbox.munki.recipe
+++ b/Dropbox/Dropbox.munki.recipe
@@ -71,35 +71,14 @@ fi
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-            <key>Arguments</key>
-            <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>installs</key>
-                    <array>
-                        <dict>
-                            <key>CFBundleIdentifier</key>
-                            <string>com.getdropbox.dropbox</string>
-                            <key>CFBundleName</key>
-                            <string>Dropbox</string>
-                            <key>path</key>
-                            <string>/Applications/Dropbox.app</string>
-                            <key>type</key>
-                            <string>file</string>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+		        <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>


### PR DESCRIPTION
I see that this recipe hasn't been updated in 3 years and it seems that Dropbox behavior has changed with respect to what happens in user directories. Humbly proposing that it should simply update the system application in /Applications. Removed the MunkipkginfoMerger processor and added CFBundleVersion comparison to arguments.
