### PR TITLE
Update Powerpoint code signature

### DIFF
--- a/MSOfficeUpdates/MSPowerPoint2016.download.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.download.recipe
@@ -74,7 +74,7 @@ the latest full update for the given CHANNEL.
                 <string>%pathname%</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Microsoft Corporation</string>
+                    <string>Developer ID Installer: Microsoft Corporation (UBF8T346G9)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
Code signature changed again. This time it should be valid going forward per Paul Bowden in the macadmins Slack instance: https://macadmins.slack.com/archives/microsoft-office/p1479306545009856