### PR TITLE
Developer cert update for Office 2011

### DIFF
--- a/MSOfficeUpdates/MSOffice2011Updates.download.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.download.recipe
@@ -57,7 +57,7 @@ If you would like to use an undocumented HTTPS download, set DOWNLOAD_URL_SCHEME
                 <string>%pathname%/Office*.*pkg</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Microsoft Corporation</string>
+                    <string>Developer ID Installer: Microsoft Corporation (UBF8T346G9)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
Code signature changed again. This time it should be valid going forward per Paul Bowden in the macadmins Slack instance: https://macadmins.slack.com/archives/microsoft-office/p1479306545009856