### PR TITLE
Updated Handbrake Recipes

### DIFF
--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -35,7 +35,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https:/handbrake.fr/%match%</string>
+                <string>https://handbrake.fr/%match%</string>
             </dict>
         </dict>
         <dict>

--- a/Handbrake/Handbrake.munki.recipe
+++ b/Handbrake/Handbrake.munki.recipe
@@ -35,8 +35,13 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+            </dict>
             <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
+            <string>MunkiInfoCreator</string>
         </dict>
         <dict>
             <key>Arguments</key>


### PR DESCRIPTION
.munki recipe was failing with: "MunkiPkginfoMerger requires missing
argument additional_pkginfo"

.download seemed to have a missing ‘/‘.

Corrected both