### PR TITLE
Removed un-needed MunkiInfoCreator from Handbrake.recipe

### DIFF
--- a/Handbrake/Handbrake.munki.recipe
+++ b/Handbrake/Handbrake.munki.recipe
@@ -39,15 +39,6 @@
             <dict>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiInfoCreator</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>version_comparison_key</key>


### PR DESCRIPTION
As per conversation with @timsutton 