### PR TITLE
bump default version

### DIFF
--- a/Puppetlabs/Puppet-Agent.download.recipe
+++ b/Puppetlabs/Puppet-Agent.download.recipe
@@ -14,7 +14,7 @@ OS_VERSION can be overridden, or left to the default, '10.10'.</string>
 		<key>NAME</key>
 		<string>Puppet-Agent</string>
 		<key>OS_VERSION</key>
-		<string>10.10</string>
+		<string>10.12</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.1</string>

--- a/Puppetlabs/Puppet-Agent.munki.recipe
+++ b/Puppetlabs/Puppet-Agent.munki.recipe
@@ -17,7 +17,7 @@ specifically for each OS, we're setting the 'minimum_os_version' and 'maximum_os
 		<key>NAME</key>
 		<string>Puppet-Agent</string>
 		<key>OS_VERSION</key>
-		<string>10.10</string>
+		<string>10.12</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>


### PR DESCRIPTION
Sierra versions have been available for a while, even though some folks
push the oldest version per clients they need to support. Still tracking https://tickets.puppetlabs.com/browse/PA-271