### PR TITLE
Updated download URL

### DIFF
--- a/Silverlight/Silverlight.download.recipe
+++ b/Silverlight/Silverlight.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Silverlight</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://www.microsoft.com/getsilverlight/handlers/getsilverlight.ashx</string>
+        <string>http://go.microsoft.com/fwlink/?LinkID=229322</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>


### PR DESCRIPTION
Old download URL now goes to a download page that lists direct-download links.