### PR TITLE
Add prerelease recipe for munkitools3.

### DIFF
--- a/munkitools/munkitools3.munki.recipe
+++ b/munkitools/munkitools3.munki.recipe
@@ -1,0 +1,419 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Note: munkitools does not include a code signature. If your
+organization requires code signature, it is recommend to internally sign
+the application.
+
+Downloads and imports version 3 of the Munki tools via
+the official releases listing on GitHub.
+
+By default only "final" releases are included. Set INCLUDE_PRERELEASES
+to a non-empty value to include releases on GitHub marked as
+"prereleases."
+
+This recipe cannot be overridden to pull a download from an
+alternate location such as munkibuilds.org - it will only download the
+official releases. For this, use the munkitools3-autobuild.munki
+recipe. Assuming you are overriding this recipe, you can copy your
+existing override for use with the autobuild recipe.
+
+The GitHubReleasesInfoProvider processor used by this recipe also
+respects an input variable: 'sort_by_highest_tag_names', which
+if set, will ignore the post dates of the releases and instead sort
+descending by tag names according to LooseVersion semantics.
+
+MUNKI_ICON should be overridden with your icon name.
+</string>
+    <key>Identifier</key>
+    <string>com.github.autopkg.munki.munkitools3</string>
+    <key>Input</key>
+    <dict>
+        <key>INCLUDE_PRERELEASES</key>
+        <string>True</string>
+        <key>NAME</key>
+        <string>munkitools3</string>
+        <key>MUNKI_CATALOG</key>
+        <string>development</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>munkitools</string>
+        <key>MUNKI_DEVELOPER</key>
+        <string>The Munki Project</string>
+        <key>MUNKI_ICON</key>
+        <string></string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>munkitools</string>
+        <!--  -->
+        <key>MUNKITOOLS_CORE_NAME</key>
+        <string>munkitools_core</string>
+        <key>MUNKITOOLS_CORE_DISPLAYNAME</key>
+        <string>Managed Software Center core tools</string>
+        <key>MUNKITOOLS_CORE_DESCRIPTION</key>
+        <string>Core command-line tools used by Managed Software Center.</string>
+        <!--  -->
+        <key>MUNKITOOLS_ADMIN_NAME</key>
+        <string>munkitools_admin</string>
+        <key>MUNKITOOLS_ADMIN_DISPLAYNAME</key>
+        <string>Managed Software Center admin tools</string>
+        <key>MUNKITOOLS_ADMIN_DESCRIPTION</key>
+        <string>Command-line Managed Software Center admin tools.</string>
+        <!--  -->
+        <key>MUNKITOOLS_APP_NAME</key>
+        <string>munkitools</string>
+        <key>MUNKITOOLS_APP_DISPLAYNAME</key>
+        <string>Managed Software Center</string>
+        <key>MUNKITOOLS_APP_DESCRIPTION</key>
+        <string>Managed Software Center application.</string>
+        <!--  -->
+        <key>MUNKITOOLS_APP_USAGE_NAME</key>
+        <string>munkitools_app_usage</string>
+        <key>MUNKITOOLS_APP_USAGE_DISPLAYNAME</key>
+        <string>Managed Software Center app usage</string>
+        <key>MUNKITOOLS_APP_USAGE_DESCRIPTION</key>
+        <string>Application usage statistics for Managed Software Center.</string>
+        <!--  -->
+        <key>MUNKITOOLS_LAUNCHD_NAME</key>
+        <string>munkitools_launchd</string>
+        <key>MUNKITOOLS_LAUNCHD_DISPLAYNAME</key>
+        <string>Managed Software Center launchd files</string>
+        <key>MUNKITOOLS_LAUNCHD_DESCRIPTION</key>
+        <string>launchd configuration files for use by Managed Software Center.</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>asset_regex</key>
+                <string>^munkitools-3.*?pkg$</string>
+                <key>github_repo</key>
+                <string>munki/munki</string>
+                <key>include_prereleases</key>
+                <string>%INCLUDE_PRERELEASES%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/repack</string>
+                <key>pkgdirs</key>
+                <dict/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_core-*</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgPacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_flatpkg_dir</key>
+                <string>%found_filename%</string>
+                <key>destination_pkg</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_core.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_admin-*</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgPacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_flatpkg_dir</key>
+                <string>%found_filename%</string>
+                <key>destination_pkg</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_admin.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_app-*</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgPacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_flatpkg_dir</key>
+                <string>%found_filename%</string>
+                <key>destination_pkg</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_app_usage-*</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgPacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_flatpkg_dir</key>
+                <string>%found_filename%</string>
+                <key>destination_pkg</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app_usage.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_launchd-*</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgPacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_flatpkg_dir</key>
+                <string>%found_filename%</string>
+                <key>destination_pkg</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_launchd.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_core.pkg</string>
+                <key>pkginfo</key>
+                <dict>
+                    <key>catalogs</key>
+                    <array>
+                        <string>%MUNKI_CATALOG%</string>
+                    </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
+                    <key>description</key>
+                    <string>%MUNKITOOLS_CORE_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
+                    <key>display_name</key>
+                    <string>%MUNKITOOLS_CORE_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
+                    <key>minimum_os_version</key>
+                    <string>10.8.0</string>
+                    <key>name</key>
+                    <string>%MUNKITOOLS_CORE_NAME%</string>
+                    <key>requires</key>
+                    <array>
+                        <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
+                    </array>
+                    <key>unattended_install</key>
+                    <true/>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_admin.pkg</string>
+                <key>pkginfo</key>
+                <dict>
+                    <key>catalogs</key>
+                    <array>
+                        <string>%MUNKI_CATALOG%</string>
+                    </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
+                    <key>description</key>
+                    <string>%MUNKITOOLS_ADMIN_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
+                    <key>display_name</key>
+                    <string>%MUNKITOOLS_ADMIN_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
+                    <key>minimum_os_version</key>
+                    <string>10.8.0</string>
+                    <key>name</key>
+                    <string>%MUNKITOOLS_ADMIN_NAME%</string>
+                    <key>unattended_install</key>
+                    <true/>
+                    <key>update_for</key>
+                    <array>
+                        <string>%MUNKITOOLS_CORE_NAME%</string>
+                    </array>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app.pkg</string>
+                <key>pkginfo</key>
+                <dict>
+                    <key>catalogs</key>
+                    <array>
+                        <string>%MUNKI_CATALOG%</string>
+                    </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
+                    <key>description</key>
+                    <string>%MUNKITOOLS_APP_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
+                    <key>display_name</key>
+                    <string>%MUNKITOOLS_APP_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
+                    <key>minimum_os_version</key>
+                    <string>10.8.0</string>
+                    <key>name</key>
+                    <string>%MUNKITOOLS_APP_NAME%</string>
+                    <key>requires</key>
+                    <array>
+                        <string>%MUNKITOOLS_CORE_NAME%</string>
+                        <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
+                    </array>
+                    <key>unattended_install</key>
+                    <true/>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app_usage.pkg</string>
+                <key>pkginfo</key>
+                <dict>
+                    <key>catalogs</key>
+                    <array>
+                        <string>%MUNKI_CATALOG%</string>
+                    </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
+                    <key>description</key>
+                    <string>%MUNKITOOLS_APP_USAGE_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
+                    <key>display_name</key>
+                    <string>%MUNKITOOLS_APP_USAGE_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
+                    <key>minimum_os_version</key>
+                    <string>10.8.0</string>
+                    <key>name</key>
+                    <string>%MUNKITOOLS_APP_USAGE_NAME%</string>
+                    <key>requires</key>
+                    <array>
+                        <string>%MUNKITOOLS_CORE_NAME%</string>
+                        <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
+                    </array>
+                    <key>unattended_install</key>
+                    <true/>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/repack/munkitools_launchd.pkg</string>
+                <key>pkginfo</key>
+                <dict>
+                    <key>catalogs</key>
+                    <array>
+                        <string>%MUNKI_CATALOG%</string>
+                    </array>
+                    <key>category</key>
+                    <string>%MUNKI_CATEGORY%</string>
+                    <key>description</key>
+                    <string>%MUNKITOOLS_LAUNCHD_DESCRIPTION%</string>
+                    <key>developer</key>
+                    <string>%MUNKI_DEVELOPER%</string>
+                    <key>display_name</key>
+                    <string>%MUNKITOOLS_LAUNCHD_DISPLAYNAME%</string>
+                    <key>icon_name</key>
+                    <string>%MUNKI_ICON%</string>
+                    <key>minimum_os_version</key>
+                    <string>10.8.0</string>
+                    <key>name</key>
+                    <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
+                </dict>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
This adds `munkitools3.munki.recipe`, with `INCLUDE_PRERELEASES` set to `True`. Changes from munkitools2:

2 -> 3
Adds `munkitools_app_usage` package.
Minimum OS version 10.8.
