### PR TITLE
Update Adobe Reader DC with new cert information

### DIFF
--- a/AdobeReader/AdobeReaderDC.download.recipe
+++ b/AdobeReader/AdobeReaderDC.download.recipe
@@ -54,7 +54,7 @@
                 <string>%pathname%/*.pkg</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Adobe Systems, Inc.</string>
+                    <string>Developer ID Installer: Adobe Systems, Inc. (JQ525L2MZD)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
The latest Reader DC appears to have a new certificate. Here's the output from a verbose run:

CodeSignatureVerifier: Mounted disk image /Users/admin/Library/AutoPkg/Cache/local.munki.AdobeReaderDC/downloads/AdobeReaderDC.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.vbOjbE/AcroRdrDC_1700920044_MUI.pkg' matched from globbed '/private/tmp/dmg.vbOjbE/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AcroRdrDC_1700920044_MUI.pkg":
CodeSignatureVerifier:    Status: signed by a certificate trusted by Mac OS X
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Adobe Systems, Inc. (JQ525L2MZD)
CodeSignatureVerifier:        SHA1 fingerprint: F8 32 AC 81 E4 A3 FE A7 19 8E 1C 00 34 A2 F5 B4 F1 A2 BB 55
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Mismatch in authority names
CodeSignatureVerifier: Expected: Developer ID Installer: Adobe Systems, Inc. -> Developer ID Certification Authority -> Apple Root CA
CodeSignatureVerifier: Found:    Developer ID Installer: Adobe Systems, Inc. (JQ525L2MZD) -> Developer ID Certification Authority -> Apple Root CA
Mismatch in authority names. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.