### PR TITLE
Post install script white space

### DIFF
--- a/Spotify/Spotify.munki.recipe
+++ b/Spotify/Spotify.munki.recipe
@@ -35,15 +35,15 @@ https://github.com/autopkg/recipes/issues/196
             <string>%NAME%</string>
             <key>postinstall_script</key>
             <string>#!/bin/bash
-                # Explicitly setting all binaries to be group and world executable, as the
-                # source dmg may have them set as 744.
-                /bin/chmod go+x \
-                '/Applications/Spotify.app/Contents/Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework' \
-                '/Applications/Spotify.app/Contents/Frameworks/Spotify Helper.app/Contents/MacOS/Spotify Helper' \
-                /Applications/Spotify.app/Contents/MacOS/Spotify \
-                /Applications/Spotify.app/Contents/MacOS/SpotifyWebHelper \
-                /Applications/Spotify.app/Contents/MacOS/sp_relauncher
-            </string>
+# Explicitly setting all binaries to be group and world executable, as the
+# source dmg may have them set as 744.
+/bin/chmod go+x \
+'/Applications/Spotify.app/Contents/Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework' \
+'/Applications/Spotify.app/Contents/Frameworks/Spotify Helper.app/Contents/MacOS/Spotify Helper' \
+/Applications/Spotify.app/Contents/MacOS/Spotify \
+/Applications/Spotify.app/Contents/MacOS/SpotifyWebHelper \
+/Applications/Spotify.app/Contents/MacOS/sp_relauncher
+</string>
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
Removed leading white space from postinstall_script. PI will not get generated in pkgsinfo file otherwise.