### PR TITLE
scrape checksum, verify as part of download

### DIFF
--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -40,8 +40,30 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://github.com/HandBrake/HandBrake/wiki/Checksums</string>
+                <key>re_pattern</key>
+                <string>(?&lt;=dmg&lt;/td&gt;\n&lt;td&gt;\d\d.\d\d&lt;/td&gt;\n&lt;td&gt;[a-z,0-9]{40}&lt;/td&gt;\n&lt;td&gt;)([a-z,0-9]*)(?=&lt;/t)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>io.github.hjuutilainen.SharedProcessors/ChecksumVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>algorithm</key>
+                <string>SHA256</string>
+                <key>checksum</key>
+                <string>%match%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
-    </array>
+   </array>
 </dict>
 </plist>


### PR DESCRIPTION
Introduces dependency on @hjuutilainen's ChecksumVerifier. Regex may be a touch brittle since it's parsing multi-line output and just returning the first sha256 after the string `dmg`, and there's a fixed-length need to assume a four digit xx.xx 'version' in the middle, but 'works on my machine'. Inadvertently smacked some whitespace, but verifies it runs... can we think about using tab chars in XML in the future?