### PR TITLE
Update Handbrake download recipe

### DIFF
--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -29,6 +29,17 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://handbrake.fr/%match%</string>
+                <key>re_pattern</key>
+                <string>(mirror.*?\.dmg)</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The download now requires two URLTextSearch steps.

Because of #200 handbrake probably introduced a new download process, which requires another URLTextSearcher step. Right now the download fails and this PR fixes this.
It's a quick fix until #202 is solved.