### PR TITLE
Glob code signature verification on Firefox.app download

### DIFF
--- a/Mozilla/Firefox.download.recipe
+++ b/Mozilla/Firefox.download.recipe
@@ -60,7 +60,7 @@ See the following URLs for more info:
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/Firefox.app</string>
+                <string>%pathname%/Firefox*.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "43AQ936H96"</string>
             </dict>

--- a/Mozilla/Firefox.download.recipe
+++ b/Mozilla/Firefox.download.recipe
@@ -59,6 +59,8 @@ See the following URLs for more info:
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
+                <key>comment</key>
+                <string>Use wildcard matching for the app so it will also match FirefoxDeveloperEdition.app and FirefoxNightly.app</string>
                 <key>input_path</key>
                 <string>%pathname%/Firefox*.app</string>
                 <key>requirement</key>


### PR DESCRIPTION
For the `Firefox.download.recipe`, the code signature verification step is looking for `Firefox.app` inside the downloaded DMG. Code signature verification will fail when using the recipe on either the Nightly or Developer Edition.

If you change the `RELEASE` to `devedition-latest`, the dmg contains `FirefoxDeveloperEdition.app` instead of `Firefox.app`. Changing the code signature verification to look for `Firefox*.app` allows the recipe to work with the Developer Edition as well as the Nightly (`FirefoxNightly.app`).

**Sample run:**
```
~ $ autopkg run Firefox.download.recipe -v
Processing Firefox.download.recipe...
WARNING: Firefox.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MozillaURLProvider
MozillaURLProvider: Found URL https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 24 Aug 2017 11:08:11 GMT
URLDownloader: Storing new ETag header: "05c665b32b76bb8b2f52fc70fdc954d5"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.autopkg.download.firefox-rc-en_US/downloads/Firefox.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/cwhits/Library/AutoPkg/Cache/com.github.autopkg.download.firefox-rc-en_US/downloads/Firefox.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.oBbx83/FirefoxNightly.app' matched from globbed '/private/tmp/dmg.oBbx83/Firefox*.app'.
CodeSignatureVerifier: Verifying application bundle signature...
CodeSignatureVerifier: /private/tmp/dmg.oBbx83/FirefoxNightly.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.oBbx83/FirefoxNightly.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.oBbx83/FirefoxNightly.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.autopkg.download.firefox-rc-en_US/receipts/Firefox.download-receipt-20170824-125139.plist

The following new items were downloaded:
    Download Path                                                                                           
    -------------                                                                                           
    /Users/cwhits/Library/AutoPkg/Cache/com.github.autopkg.download.firefox-rc-en_US/downloads/Firefox.dmg  
```