### PR TITLE
Replace "OracleJava8" with "%NAME%" variable in "pkg_path" string

### DIFF
--- a/OracleJava/OracleJava8.pkg.recipe
+++ b/OracleJava/OracleJava8.pkg.recipe
@@ -91,7 +91,7 @@ http://www.oracle.com/technetwork/java/javase/terms/license/index.html
 				<key>source_pkg</key>
                 <string>%pathname%/Java 8 Update*.app/Contents/Resources/JavaAppletPlugin.pkg</string>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/OracleJava8-%version%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Most recipes contain the %NAME% variable in the pkg_path string, meaning that the outputted pkg file will respect whatever value is set within the "NAME" input within each recipe. Not a big deal, but this change would mean that I wouldn't have to create a completely separate recipe within my own AutoPkg repo just for this change; it would also make it more consistent with other recipes.