### PR TITLE
Change version string from CFBundleShortVersionString

### DIFF
--- a/Skype/Skype.pkg.recipe
+++ b/Skype/Skype.pkg.recipe
@@ -24,7 +24,7 @@
                 <string>%pathname%/Skype.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
                 <dict>
-                    <key>CFBundleVersion</key>
+                    <key>CFBundleShortVersionString</key>
                     <string>version</string>
                     <key>CFBundleIdentifier</key>
                     <string>bundleid</string>


### PR DESCRIPTION
Changed version string to CFBundleShortVersionString to avoid update loops with JAMF Pro etc.