### PR TITLE
Added ability to pull standalone installers with MSOfficeUpdates

### DIFF
--- a/MSOfficeUpdates/MSExcel2016.download.recipe
+++ b/MSOfficeUpdates/MSExcel2016.download.recipe
@@ -17,8 +17,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSExcel2016</string>

--- a/MSOfficeUpdates/MSExcel2016.munki.recipe
+++ b/MSOfficeUpdates/MSExcel2016.munki.recipe
@@ -21,8 +21,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.MSExcel2016</string>

--- a/MSOfficeUpdates/MSOffice2016URLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOffice2016URLandUpdateInfoProvider.py
@@ -50,7 +50,7 @@ PROD_DICT = {
     }
 }
 LOCALE_ID_INFO_URL = "https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx"
-SUPPORTED_VERSIONS = ["latest", "latest-delta"]
+SUPPORTED_VERSIONS = ["latest", "latest-delta", "Standalone"]
 DEFAULT_VERSION = "latest"
 CHANNELS = {
     'Production': 'C1297A47-86C4-4C1F-97FA-950631F94777',
@@ -217,7 +217,7 @@ class MSOffice2016URLandUpdateInfoProvider(Processor):
         # have two items: a full and a delta. Delta updates will have a
         # 'FullUpdaterLocation' key, so filter by the array according to
         # which item has that key.
-        if self.env["version"] == "latest":
+        if self.env["version"] == "latest" or self.env["type"] == "Standalone":
             item = [u for u in metadata if not u.get("FullUpdaterLocation")]
         elif self.env["version"] == "latest-delta":
             item = [u for u in metadata if u.get("FullUpdaterLocation")]
@@ -225,6 +225,13 @@ class MSOffice2016URLandUpdateInfoProvider(Processor):
             raise ProcessorError("Could not find an applicable update in "
                                  "update metadata.")
         item = item[0]
+        
+        if self.env["type"] == "Standalone":
+            p = re.compile(ur'(^[a-zA-Z0-9:/.-]*_[a-zA-Z]*_)(.*)Updater.pkg')
+            url = item["Location"]
+            (firstGroup, secondGroup) = re.search(p, url).group(1, 2)
+            item["Location"] = firstGroup + "2016_"+ secondGroup + "Installer.pkg"
+
 
         self.env["url"] = item["Location"]
         self.output("Found URL %s" % self.env["url"])

--- a/MSOfficeUpdates/MSOffice2016URLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOffice2016URLandUpdateInfoProvider.py
@@ -217,7 +217,7 @@ class MSOffice2016URLandUpdateInfoProvider(Processor):
         # have two items: a full and a delta. Delta updates will have a
         # 'FullUpdaterLocation' key, so filter by the array according to
         # which item has that key.
-        if self.env["version"] == "latest" or self.env["type"] == "Standalone":
+        if self.env["version"] == "latest" or self.env["version"] == "Standalone":
             item = [u for u in metadata if not u.get("FullUpdaterLocation")]
         elif self.env["version"] == "latest-delta":
             item = [u for u in metadata if u.get("FullUpdaterLocation")]
@@ -226,7 +226,7 @@ class MSOffice2016URLandUpdateInfoProvider(Processor):
                                  "update metadata.")
         item = item[0]
         
-        if self.env["type"] == "Standalone":
+        if self.env["version"] == "Standalone":
             p = re.compile(ur'(^[a-zA-Z0-9:/.-]*_[a-zA-Z]*_)(.*)Updater.pkg')
             url = item["Location"]
             (firstGroup, secondGroup) = re.search(p, url).group(1, 2)

--- a/MSOfficeUpdates/MSOneNote2016.download.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.download.recipe
@@ -17,8 +17,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSOneNote2016</string>

--- a/MSOfficeUpdates/MSOneNote2016.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.munki.recipe
@@ -21,8 +21,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.MSOneNote2016</string>

--- a/MSOfficeUpdates/MSOutlook2016.download.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.download.recipe
@@ -17,8 +17,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSOutlook2016</string>

--- a/MSOfficeUpdates/MSOutlook2016.munki.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.munki.recipe
@@ -21,8 +21,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.MSOutlook2016</string>

--- a/MSOfficeUpdates/MSPowerPoint2016.download.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.download.recipe
@@ -17,8 +17,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSPowerPoint2016</string>

--- a/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
@@ -21,8 +21,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.MSPowerPoint2016</string>

--- a/MSOfficeUpdates/MSWord2016.download.recipe
+++ b/MSOfficeUpdates/MSWord2016.download.recipe
@@ -17,8 +17,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSWord2016</string>

--- a/MSOfficeUpdates/MSWord2016.munki.recipe
+++ b/MSOfficeUpdates/MSWord2016.munki.recipe
@@ -21,8 +21,12 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION currently only supports one value: 'latest', which will download
-the latest full update for the given CHANNEL.
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.MSWord2016</string>


### PR DESCRIPTION
MSOfficeUpdates currently only supports pulling combo and delta updates. This PR adds the ability to pull standalone installers as well and updates documentation on affected recipes.

See https://clburlison.com/demystify-office2016/ to understand importance... TL;DR is that the standalone installers include MAU + licensing tools required for initial deployment. 