### PR TITLE
Bumped OS_VERSION in all AdobeReaderDC recipes

### DIFF
--- a/AdobeReader/AdobeReaderDC.install.recipe
+++ b/AdobeReader/AdobeReaderDC.install.recipe
@@ -15,7 +15,7 @@
         <key>MAJOR_VERSION</key>
         <string>AcrobatDC</string>
         <key>OS_VERSION</key>
-        <string>10.9.0</string>
+        <string>10.10.0</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>

--- a/AdobeReader/AdobeReaderDC.munki.recipe
+++ b/AdobeReader/AdobeReaderDC.munki.recipe
@@ -11,7 +11,7 @@
         <key>MAJOR_VERSION</key>
         <string>AcrobatDC</string>
         <key>OS_VERSION</key>
-        <string>10.9.0</string>
+        <string>10.10.0</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/Adobe</string>
 		<key>NAME</key>

--- a/AdobeReader/AdobeReaderDC.pkg.recipe
+++ b/AdobeReader/AdobeReaderDC.pkg.recipe
@@ -14,7 +14,7 @@ and enabling installation on non-boot volumes.</string>
         <key>MAJOR_VERSION</key>
         <string>AcrobatDC</string>
         <key>OS_VERSION</key>
-        <string>10.9.0</string>
+        <string>10.10.0</string>
         <key>NAME</key>
         <string>AdobeReaderDC</string>
     </dict>


### PR DESCRIPTION
Otherwise these recipes override the download recipe.