### PR TITLE
Download URL updated

### DIFF
--- a/Spotify/Spotify.download.recipe
+++ b/Spotify/Spotify.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Spotify</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://www.spotify.com/download/Spotify.dmg</string>
+        <string>https://download.scdn.co/Spotify.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>


### PR DESCRIPTION
Old URL pointed to an old version, new URL found in the "SpotifyInstaller", downloads most recent version.