### PR TITLE
Collect additional Version Strings

### DIFF
--- a/OracleJava/OracleJava8.pkg.recipe
+++ b/OracleJava/OracleJava8.pkg.recipe
@@ -75,10 +75,12 @@ http://www.oracle.com/technetwork/java/javase/terms/license/index.html
                 <key>info_path</key>
                 <string>%RECIPE_CACHE_DIR%/unpack/root/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Enabled.plist</string>
                 <key>plist_keys</key>
-				<dict>
-					<key>CFBundleVersion</key>
-					<string>version</string>
-				</dict>
+                <dict>
+                    <key>CFBundleVersion</key>
+                    <string>versionString</string>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                </dict>
             </dict>
             <key>Processor</key>
             <string>PlistReader</string>
@@ -91,7 +93,7 @@ http://www.oracle.com/technetwork/java/javase/terms/license/index.html
 				<key>source_pkg</key>
                 <string>%pathname%/Java 8 Update*.app/Contents/Resources/JavaAppletPlugin.pkg</string>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%versionString%.pkg</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
This will allow to use the expected "numbered version" (CFBundleVersion) for the package name, and then use the JavaAppletPlugin.plugin display version (CFBundleShortVersionString) for version comparison operations (in say Jamf, without needing an extension attribute).

The point of this is to remove unnecessary Extension Attributes in Jamf for data that's already collected natively.  I can use CFBundleShortVersionString in a Smart Group updated by a .jss recipe.

I'm not sure if this will affect Munki use and child recipes, it's been a couple years since I've used Munki.  If it will, then it can be denied and I'll just use a custom recipe.