### PR TITLE
Spotify chmod/post_install fix for StartUpHelper

### DIFF
--- a/Spotify/Spotify.munki.recipe
+++ b/Spotify/Spotify.munki.recipe
@@ -42,7 +42,8 @@ https://github.com/autopkg/recipes/issues/196
                 '/Applications/Spotify.app/Contents/Frameworks/Spotify Helper.app/Contents/MacOS/Spotify Helper' \
                 /Applications/Spotify.app/Contents/MacOS/Spotify \
                 /Applications/Spotify.app/Contents/MacOS/SpotifyWebHelper \
-                /Applications/Spotify.app/Contents/MacOS/sp_relauncher
+                /Applications/Spotify.app/Contents/MacOS/sp_relauncher \
+                /Applications/Spotify.app/Contents/Library/LoginItems/StartUpHelper.app/Contents/MacOS/StartUpHelper
             </string>
             <key>unattended_install</key>
             <true/>


### PR DESCRIPTION
A spotify installation went crazy because this item (also) had the wrong permissions.

```
Mar 27 16:06:49 machine com.apple.xpc.launchd[1] (com.spotify.client.startuphelper[12365]): Could not find and/or execute program specified by service: 13: Permission denied: com.spotify.client.startuphelper
Mar 27 16:06:49 machine com.apple.xpc.launchd[1] (com.spotify.client.startuphelper[12365]): Service setup event to handle failure and will not launch until it fires.
```

Tested it and it seems to work fine now.