### PR TITLE
add signature checking to Chrome

### DIFF
--- a/GoogleChrome/GoogleChrome.download.recipe
+++ b/GoogleChrome/GoogleChrome.download.recipe
@@ -32,6 +32,19 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Google Chrome.app</string>
+                <key>strict_verification</key>
+                <false/>
+                <key>requirement</key>
+                <string>(identifier "com.google.Chrome" or identifier "com.google.Chrome.beta" or identifier "com.google.Chrome.dev" or identifier "com.google.Chrome.canary") and (certificate leaf = H"85cee8254216185620ddc8851c7a9fc4dfe120ef" or certificate leaf = H"c9a99324ca3fcb23dbcc36bd5fd4f9753305130a")</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Addresses #158. While not strict, IMO it's better than no checking whatsoever. Google themselves can't/don't do strict checking, as per [the long-unchanged master version of their build script](https://chromium.googlesource.com/chromium/src.git/+/master/chrome/installer/mac/sign_app.sh.in#95) (if I'm looking in the right place).
```py
CodeSignatureVerifier
{'Input': {'input_path': u'/Users/allister/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg/Google Chrome.app',
           'requirement': u'(identifier "com.google.Chrome" or identifier "com.google.Chrome.beta" or identifier "com.google.Chrome.dev" or identifier "com.google.Chrome.canary") and (certificate leaf = H"85cee8254216185620ddc8851c7a9fc4dfe120ef" or certificate leaf = H"c9a99324ca3fcb23dbcc36bd5fd4f9753305130a")',
           'strict_verification': False}}
CodeSignatureVerifier: Mounted disk image /Users/allister/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification disabled...
CodeSignatureVerifier: /private/tmp/dmg.9IRrUZ/Google Chrome.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.9IRrUZ/Google Chrome.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.9IRrUZ/Google Chrome.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```
Tested runs with autopkg versions 1.0.3 and 1.0.4, macOS 10.12.5 and 10.13.6(17G39b) 