### PR TITLE
Update TheUnarchiver.download.recipe

### DIFF
--- a/The Unarchiver/TheUnarchiver.download.recipe
+++ b/The Unarchiver/TheUnarchiver.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>TheUnarchiver</string>
         <key>SPARKLE_FEED_URL</key>
-        <string>https://updates.devmate.com/cx.c3.theunarchiver.xml</string>
+        <string>https://updates.devmate.com/com.macpaw.site.theunarchiver.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>
@@ -61,7 +61,7 @@
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/The Unarchiver.app</string>
                 <key>requirement</key>
-                <string>anchor apple generic and identifier "cx.c3.theunarchiver" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S8EX82NJP6)</string>
+                <string>anchor apple generic and identifier "com.macpaw.site.theunarchiver" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S8EX82NJP6)</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
TheUnarchiver is now owned by MacPaw and the existing URL doesn't find updates anymore. This request updates the URL and certificate for the app.