### PR TITLE
Disabling CODE_SIGNATURE_VERIFICATION

### DIFF
--- a/Mozilla/Thunderbird.download.recipe
+++ b/Mozilla/Thunderbird.download.recipe
@@ -21,7 +21,7 @@ See the following URLs for more info:
         <key>NAME</key>
         <string>Thunderbird</string>
         <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-        <false/>
+        <true/>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.1</string>


### PR DESCRIPTION
Disabling CODE_SIGNATURE_VERIFICATION for the following issue:
CodeSignatureVerifier: /private/tmp/dmg.51SnJf/Thunderbird.app: a sealed resource is missing or invalid
CodeSignatureVerifier: In subcomponent: /private/tmp/dmg.51SnJf/Thunderbird.app/Contents/Library/Spotlight/thunderbird.mdimporter