### PR TITLE
Define the MSOfficeUpdates developer and category

### DIFF
--- a/MSOfficeUpdates/MSAutoUpdate.munki.recipe
+++ b/MSOfficeUpdates/MSAutoUpdate.munki.recipe
@@ -56,6 +56,8 @@ the latest full update for the given CHANNEL.
             <true/>
 	    <key>developer</key>
  	    <string>Microsoft</string>
+            <key>category</key>
+            <string>Productivity</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSAutoUpdate.munki.recipe
+++ b/MSOfficeUpdates/MSAutoUpdate.munki.recipe
@@ -54,6 +54,8 @@ the latest full update for the given CHANNEL.
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+	    <key>developer</key>
+ 	    <string>Microsoft</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSExcel2016.munki.recipe
+++ b/MSOfficeUpdates/MSExcel2016.munki.recipe
@@ -58,6 +58,8 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+            <key>developer</key>
+	    <string>Microsoft</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
@@ -72,6 +72,8 @@ certificate for the downloaded update can still be manually verified, however.
             </array>
 	    <key>developer</key>
 	    <string>Microsoft</string>
+	    <key>category</key>
+	    <string>Productivity</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>

--- a/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
+++ b/MSOfficeUpdates/MSOffice2011Updates.munki.recipe
@@ -70,6 +70,8 @@ certificate for the downloaded update can still be manually verified, however.
             <array>
                 <string>Office2011</string>
             </array>
+	    <key>developer</key>
+	    <string>Microsoft</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>

--- a/MSOfficeUpdates/MSOneNote2016.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.munki.recipe
@@ -58,6 +58,8 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+	    <key>developer</key>
+	    <string>Microsoft</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSOneNote2016.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.munki.recipe
@@ -60,6 +60,8 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <true/>
 	    <key>developer</key>
 	    <string>Microsoft</string>
+            <key>category</key>
+            <string>Productivity</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSOutlook2016.munki.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.munki.recipe
@@ -58,6 +58,8 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+	    <key>developer</key>
+	    <string>Microsoft</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSOutlook2016.munki.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.munki.recipe
@@ -60,6 +60,8 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <true/>
 	    <key>developer</key>
 	    <string>Microsoft</string>
+            <key>category</key>
+            <string>Productivity</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
@@ -58,6 +58,8 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+	    <key>developer</key>
+	    <string>Microsoft</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
@@ -60,6 +60,8 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <true/>
 	    <key>developer</key>
 	    <string>Microsoft</string>
+            <key>category</key>
+            <string>Productivity</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSWord2016.munki.recipe
+++ b/MSOfficeUpdates/MSWord2016.munki.recipe
@@ -58,6 +58,8 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+            <key>developer</key>
+	    <string>Microsoft</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/MSWord2016.munki.recipe
+++ b/MSOfficeUpdates/MSWord2016.munki.recipe
@@ -60,6 +60,8 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <true/>
             <key>developer</key>
 	    <string>Microsoft</string>
+            <key>category</key>
+            <string>Productivity</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/SkypeForBusiness.munki.recipe
+++ b/MSOfficeUpdates/SkypeForBusiness.munki.recipe
@@ -56,6 +56,8 @@ the latest full update for the given CHANNEL.
             <true/>
 	    <key>developer</key>
 	    <string>Microsoft</string>
+            <key>category</key>
+            <string>Communication</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/MSOfficeUpdates/SkypeForBusiness.munki.recipe
+++ b/MSOfficeUpdates/SkypeForBusiness.munki.recipe
@@ -54,6 +54,8 @@ the latest full update for the given CHANNEL.
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+	    <key>developer</key>
+	    <string>Microsoft</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>


### PR DESCRIPTION
Based on this conversation:
https://macadmins.slack.com/archives/C056155B4/p1534872026000100

And this Microsoft Documentation:
https://news.microsoft.com/facts-about-microsoft/

```Microsoft refers to Microsoft Corp. and its affiliates, including Microsoft Mobile Oy, a subsidiary of Microsoft. Microsoft Mobile Oy develops, manufactures and distributes Nokia X mobile phones and other devices.```


Listing a default developer as Microsoft, and default category as `Productivity` for Office Suite (as Microsoft defines the software as a collection of productivity applications), and default type of `Communication` for SkypeForBusiness.

A custom override would still allow the autopkg/munki admin to mandate whatever developer or category they would like to use.