### PR TITLE
Remove 2016_ from latest-standalone URL in MSO processor

### DIFF
--- a/MSOfficeUpdates/MSOffice2016URLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOffice2016URLandUpdateInfoProvider.py
@@ -231,7 +231,7 @@ class MSOffice2016URLandUpdateInfoProvider(Processor):
             p = re.compile(ur'(^[a-zA-Z0-9:/.-]*_[a-zA-Z]*_)(.*)Updater.pkg')
             url = item["Location"]
             (firstGroup, secondGroup) = re.search(p, url).group(1, 2)
-            item["Location"] = firstGroup + "2016_"+ secondGroup + "Installer.pkg"
+            item["Location"] = firstGroup + secondGroup + "Installer.pkg"
 
         self.env["url"] = item["Location"]
         self.output("Found URL %s" % self.env["url"])


### PR DESCRIPTION
## Overview

Remove `2016_` from `latest-standalone` URL in MSO processor.

This reflects MSO versioning changes described here:
https://macmule.com/2018/09/24/microsoft-office-for-mac-changes-versioning-shenanigans/

Fixes #267 

## Testing Instructions

First, checkout my branch in your `com.github.autopkg.recipes` directory:

```bash
$ cd ~/Projects/autopkg/RecipeRepos/com.github.autopkg.recipes
$ git remote add rbreslow git@github.com:rbreslow/recipes.git
$ git fetch
$ git checkout feature/jrb/fix-mso-processor
```

Next, try to run the `MSWord2016.download` recipe:

```bash
$ autopkg run MSWord2016.download -k VERSION=latest-standalone
Processing MSWord2016.download...
WARNING: MSWord2016.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...

The following new items were downloaded:
    Download Path
    -------------
    /Users/rbreslow/Projects/autopkg/Cache/com.github.autopkg.download.MSWord2016/downloads/MSWord2016-16.16.18101500.pkg
```

We can verify that this is a standalone installer by checking for the presence of `Office16_all_autoupdate.pkg` and `Office16_all_licensing.pkg`:

```bash
$ cd ~/Projects/autopkg/Cache/com.github.autopkg.download.MSWord2016/downloads
$ pkgutil --expand MSWord2016-16.16.18101500.pkg expanded
$ ls expanded
total 88
-rw-r--r--   1 rbreslow  1310893680    43K Nov  4 00:35 Distribution
drwx------   6 rbreslow  1310893680   192B Nov  4 00:35 Microsoft_Word.pkg
drwx------   6 rbreslow  1310893680   192B Nov  4 00:35 Office16_all_autoupdate.pkg
drwx------   6 rbreslow  1310893680   192B Nov  4 00:35 Office16_all_licensing.pkg
drwx------  29 rbreslow  1310893680   928B Nov  4 00:35 Resources
```