### PR TITLE
Update OracleJava8.download.recipe

### DIFF
--- a/OracleJava/OracleJava8.download.recipe
+++ b/OracleJava/OracleJava8.download.recipe
@@ -29,9 +29,9 @@ http://www.oracle.com/technetwork/java/javase/terms/license/index.html
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html</string>
+                <string>https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;http://download.oracle.com/otn-pub/java/jdk/.*?/jre-8.*?x64.dmg)</string>
+                <string>(?P&lt;url&gt;https://download.oracle.com/otn-pub/java/jdk/.*?/jre-8.*?x64.dmg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi,

**http** urls does not seem to be usable anymore.
Replace **http** by **https** worked for me.

Regards,
Emmanuel