### PR TITLE
Added definition to MozillaURLProvider to obtain requested version

### DIFF
--- a/Mozilla/MozillaURLProvider.py
+++ b/Mozilla/MozillaURLProvider.py
@@ -15,13 +15,16 @@
 # limitations under the License.
 """See docstring for MozillaURLProvider class"""
 
+import urllib2
+import json
 from autopkglib import Processor, ProcessorError
 
 
 __all__ = ["MozillaURLProvider"]
 
 
-MOZ_BASE_URL = "https://download.mozilla.org/?product=%s-%s&os=osx&lang=%s"
+MOZ_BASE_URL = "https://download.mozilla.org/?product=%s-%s-SSL&os=osx&lang=%s"
+MOZ_VERSIONS_URL = "https://product-details.mozilla.org/1.0/%s_versions.json"
 
 # As of 16 Nov 2015 here are the supported products:
 # firefox-latest
@@ -29,7 +32,7 @@ MOZ_BASE_URL = "https://download.mozilla.org/?product=%s-%s&os=osx&lang=%s"
 # firefox-beta-latest
 # thunderbird-latest
 # thunderbird-beta-latest
-# 
+#
 # See also:
 #    http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt
 #    http://ftp.mozilla.org/pub/firefox/releases/latest-esr/README.txt
@@ -64,6 +67,10 @@ class MozillaURLProvider(Processor):
             "required": False,
             "description": "Default is '%s." % MOZ_BASE_URL,
         },
+        "versions_url": {
+            "required": False,
+            "description": "Default is '%s." % MOZ_VERSIONS_URL,
+        },
     }
     output_variables = {
         "url": {
@@ -71,20 +78,40 @@ class MozillaURLProvider(Processor):
         },
     }
 
-    def get_mozilla_dmg_url(self, base_url, product_name, release, locale):
+    def get_version(self, versions_url, product_name, release):
+        """Get the appropriate version number of Mozilla product"""
+        # Determine correct key name in versions json file
+        if release == "latest":
+            versions_json_name = "LATEST_%s_VERSION" % product_name.upper()
+        if release == "esr-latest":
+            versions_json_name = "%s_ESR" % product_name.upper()
+        if release == "beta-latest":
+            versions_json_name = "LATEST_%s_DEVEL_VERSION" % product_name.upper()
+
+        product_versions_url = versions_url % product_name
+
+        response = urllib2.urlopen(product_versions_url)
+        data = json.loads(response.read())
+        return data[versions_json_name]
+
+
+    def get_mozilla_dmg_url(self, base_url, versions_url, product_name, release, locale):
         """Assemble download URL for Mozilla product"""
         #pylint: disable=no-self-use
         # Allow locale as both en-US and en_US.
         locale = locale.replace("_", "-")
-        
+
         # fix releases into new format
         if release == 'latest-esr':
             release = 'esr-latest'
         if release == 'latest-beta':
             release = 'beta-latest'
 
+        # Get required version
+        requested_version = self.get_version(versions_url, product_name, release)
+
         # Construct download URL.
-        return base_url % (product_name, release, locale)
+        return base_url % (product_name, requested_version, locale)
 
     def main(self):
         """Provide a Mozilla download URL"""
@@ -93,13 +120,13 @@ class MozillaURLProvider(Processor):
         release = self.env.get("release", "latest")
         locale = self.env.get("locale", "en-US")
         base_url = self.env.get("base_url", MOZ_BASE_URL)
+        versions_url = self.env.get("versions_url", MOZ_VERSIONS_URL)
 
         self.env["url"] = self.get_mozilla_dmg_url(
-            base_url, product_name, release, locale)
+            base_url, versions_url, product_name, release, locale)
         self.output("Found URL %s" % self.env["url"])
 
 
 if __name__ == "__main__":
     PROCESSOR = MozillaURLProvider()
     PROCESSOR.execute_shell()
-


### PR DESCRIPTION
To address issue #272 I have added a definition to the `MozillaURLProvider` processor to obtain the requested version from `https://product-details.mozilla.org/1.0/%s_versions.json`, where `%s` is the existing `product_name` key - `thunderbird` or `firefox`.

This would of course affect the current `Firefox.download` recipe, which is working, as well as the `Thunderbird.download` recipe, which is not. I have tested that the amended processor functions with both products. 

This does not solve #258 which is an open bug on Mozilla's part. Users of this recipe would still have to disable Code Signature Verification to prevent the Thunderbird.download recipe failing.