### PR TITLE
Update munkitools3.munki minimum OS version to match Munki 3.6 requirements

### DIFF
--- a/munkitools/munkitools3.munki.recipe
+++ b/munkitools/munkitools3.munki.recipe
@@ -257,7 +257,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.8.0</string>
+                    <string>10.10.0</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_CORE_NAME%</string>
                     <key>requires</key>
@@ -295,7 +295,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.8.0</string>
+                    <string>10.10.0</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_ADMIN_NAME%</string>
                     <key>unattended_install</key>
@@ -333,7 +333,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.8.0</string>
+                    <string>10.10.0</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_APP_NAME%</string>
                     <key>requires</key>
@@ -372,7 +372,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.8.0</string>
+                    <string>10.10.0</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_APP_USAGE_NAME%</string>
                     <key>requires</key>


### PR DESCRIPTION
I've updated the `minimum_os_version` keys in the munkitools3.munki recipe to match the requirements mentioned in the Munki 3.6 RC 1 release notes:

> Munki 3.6 will install (and is supported) on macOS 10.10+. Older macOS versions are no longer supported.

I did not modify the launchd component requirements, as that component is unmodified in Munki 3.6.

(This PR is intended to be merged *after* Munki 3.6 is released.)