### PR TITLE
Update Microsoft AutoUpdate product ID

### DIFF
--- a/MSOfficeUpdates/MSOffice2016URLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOffice2016URLandUpdateInfoProvider.py
@@ -45,7 +45,7 @@ PROD_DICT = {
     'Word': {'id': 'MSWD15', 'path': '/Applications/Microsoft Word.app'},
     'SkypeForBusiness': {'id': 'MSFB16', 'path': '/Applications/Skype for Business.app'},
     'AutoUpdate': {
-        'id': 'MSau03',
+        'id': 'MSau04',
         'path': '/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app'
     }
 }


### PR DESCRIPTION
The latest version available with MSau03 is 4.7. The ID updated to MSau04 after that. This change reflects that change and allows downloads greater than 4.7.