### PR TITLE
Bump OS_VERSION in AdobeReaderDC recipes to 10.12.0 to be able to get…

### DIFF
--- a/AdobeReader/AdobeReaderDC.download.recipe
+++ b/AdobeReader/AdobeReaderDC.download.recipe
@@ -13,7 +13,7 @@
         <key>MAJOR_VERSION</key>
         <string>AcrobatDC</string>
         <key>OS_VERSION</key>
-        <string>10.11.0</string>
+        <string>10.12.0</string>
 		<key>NAME</key>
 		<string>AdobeReaderDC</string>
 	</dict>


### PR DESCRIPTION
… latest version

Bump OS_VERSION in AdobeReaderDC recipes to 10.12.0 to be able to get latest version