### PR TITLE
Bump OS_VERSION in AdobeReaderDC recipes to 10.12.0 to be able to get…

### DIFF
--- a/AdobeReader/AdobeReaderDC.munki.recipe
+++ b/AdobeReader/AdobeReaderDC.munki.recipe
@@ -11,7 +11,7 @@
         <key>MAJOR_VERSION</key>
         <string>AcrobatDC</string>
         <key>OS_VERSION</key>
-        <string>10.11.0</string>
+        <string>10.12.0</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/Adobe</string>
 		<key>NAME</key>
@@ -33,7 +33,7 @@
 			<key>display_name</key>
 			<string>Adobe Acrobat Reader DC</string>
 			<key>minimum_os_version</key>
-			<string>10.11.0</string>
+			<string>10.12.0</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>preinstall_script</key>


### PR DESCRIPTION
… latest version

Bump OS_VERSION in AdobeReaderDC recipes to 10.12.0 to be able to get latest version