### PR TITLE
Bump OS_VERSION in AdobeReaderDC recipes to 10.12.0 to be able to get…

### DIFF
--- a/AdobeReader/AdobeReaderDC.install.recipe
+++ b/AdobeReader/AdobeReaderDC.install.recipe
@@ -15,7 +15,7 @@
         <key>MAJOR_VERSION</key>
         <string>AcrobatDC</string>
         <key>OS_VERSION</key>
-        <string>10.11.0</string>
+        <string>10.12.0</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>


### PR DESCRIPTION
… latest version

Bump OS_VERSION in AdobeReaderDC recipes to 10.12.0 to be able to get latest version