### PR TITLE
Fix Description Typos and OneNote2016 VERSION info

### DIFF
--- a/MSOfficeUpdates/MSExcel2019.munki.recipe
+++ b/MSOfficeUpdates/MSExcel2019.munki.recipe
@@ -11,7 +11,7 @@ If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
 CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
-still be overridden in a overriden for this .munki recipe.
+still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
 that can be used for testing purposes. See the explanations in the 'Channel'

--- a/MSOfficeUpdates/MSOneNote2016.download.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.download.recipe
@@ -17,12 +17,8 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION supports three values: 'latest', which will download
-the latest full update for the given CHANNEL, 'latest-delta',
-which will download the latest delta update for the given CHANNEL,
-and 'latest-standalone' which will download the latest standalone
-installer for the given CHANNEL. 'latest-standalone' does not support
-'InsiderFast' CHANNEL.
+VERSION currently only supports one value: 'latest', which will download
+the latest full update for the given CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSOneNote2016</string>

--- a/MSOfficeUpdates/MSOneNote2016.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.munki.recipe
@@ -10,6 +10,9 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
+CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+still be overridden in an override for this .munki recipe.
+
 CHANNEL can be set to several values in order to get more frequent updates
 that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
@@ -21,12 +24,8 @@ extracted from the Microsoft update metadata. See
 https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
 for more information about locale IDs.
 
-VERSION supports three values: 'latest', which will download
-the latest full update for the given CHANNEL, 'latest-delta',
-which will download the latest delta update for the given CHANNEL,
-and 'latest-standalone' which will download the latest standalone
-installer for the given CHANNEL. 'latest-standalone' does not support
-'InsiderFast' CHANNEL.
+VERSION currently only supports one value: 'latest', which will download
+the latest full update for the given CHANNEL.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.MSOneNote2016</string>

--- a/MSOfficeUpdates/MSOneNote2019.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2019.munki.recipe
@@ -11,7 +11,7 @@ If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
 CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
-still be overridden in a overriden for this .munki recipe.
+still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
 that can be used for testing purposes. See the explanations in the 'Channel'

--- a/MSOfficeUpdates/MSOutlook2019.munki.recipe
+++ b/MSOfficeUpdates/MSOutlook2019.munki.recipe
@@ -11,7 +11,7 @@ If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
 CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
-still be overridden in a overriden for this .munki recipe.
+still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
 that can be used for testing purposes. See the explanations in the 'Channel'

--- a/MSOfficeUpdates/MSPowerPoint2019.munki.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2019.munki.recipe
@@ -11,7 +11,7 @@ If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
 CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
-still be overridden in a overriden for this .munki recipe.
+still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
 that can be used for testing purposes. See the explanations in the 'Channel'

--- a/MSOfficeUpdates/MSWord2019.munki.recipe
+++ b/MSOfficeUpdates/MSWord2019.munki.recipe
@@ -11,7 +11,7 @@ If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
 CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
-still be overridden in a overriden for this .munki recipe.
+still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
 that can be used for testing purposes. See the explanations in the 'Channel'


### PR DESCRIPTION
Fixed one typo (5 times) in munki recipes for Office products. Change the VERSION description for OneNote2016 to match the 2019 description, since the same restriction applies there.