### PR TITLE
Remove redundant OS_VERSION from AdobeReaderDC child recipes

### DIFF
--- a/AdobeReader/AdobeReader.install.recipe
+++ b/AdobeReader/AdobeReader.install.recipe
@@ -17,8 +17,6 @@ latest/last version of Adobe Reader 10, but the repackager is unlikely to operat
         <string>English</string>
         <key>MAJOR_VERSION</key>
         <string>11</string>
-        <key>OS_VERSION</key>
-        <string>10.8.0</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>

--- a/AdobeReader/AdobeReader.munki.recipe
+++ b/AdobeReader/AdobeReader.munki.recipe
@@ -22,8 +22,6 @@ preflight script, looking to find a user's trash folder to copy the .app into.
         <string>English</string>
         <key>MAJOR_VERSION</key>
         <string>11</string>
-        <key>OS_VERSION</key>
-        <string>10.8.0</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Adobe</string>
         <key>NAME</key>

--- a/AdobeReader/AdobeReader.pkg.recipe
+++ b/AdobeReader/AdobeReader.pkg.recipe
@@ -17,8 +17,6 @@ latest/last version of Adobe Reader 10, but the repackager is unlikely to operat
         <string>English</string>
         <key>MAJOR_VERSION</key>
         <string>11</string>
-        <key>OS_VERSION</key>
-        <string>10.8.0</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/AdobeReader/AdobeReaderDC.install.recipe
+++ b/AdobeReader/AdobeReaderDC.install.recipe
@@ -14,8 +14,6 @@
         <string>English</string>
         <key>MAJOR_VERSION</key>
         <string>AcrobatDC</string>
-        <key>OS_VERSION</key>
-        <string>10.11.0</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>

--- a/AdobeReader/AdobeReaderDC.munki.recipe
+++ b/AdobeReader/AdobeReaderDC.munki.recipe
@@ -31,7 +31,7 @@
 			<key>display_name</key>
 			<string>Adobe Acrobat Reader DC</string>
 			<key>minimum_os_version</key>
-			<string>10.11.0</string>
+			<string>10.12.0</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>preinstall_script</key>

--- a/AdobeReader/AdobeReaderDC.munki.recipe
+++ b/AdobeReader/AdobeReaderDC.munki.recipe
@@ -10,8 +10,6 @@
         <string>English</string>
         <key>MAJOR_VERSION</key>
         <string>AcrobatDC</string>
-        <key>OS_VERSION</key>
-        <string>10.11.0</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/Adobe</string>
 		<key>NAME</key>

--- a/AdobeReader/AdobeReaderDC.pkg.recipe
+++ b/AdobeReader/AdobeReaderDC.pkg.recipe
@@ -13,8 +13,6 @@ and enabling installation on non-boot volumes.</string>
         <string>English</string>
         <key>MAJOR_VERSION</key>
         <string>AcrobatDC</string>
-        <key>OS_VERSION</key>
-        <string>10.11.0</string>
         <key>NAME</key>
         <string>AdobeReaderDC</string>
     </dict>


### PR DESCRIPTION
Resolves #271
Resolves #297 
Resolves #298 
Resolves #299