### PR TITLE
Basic python3 compatibility

### DIFF
--- a/AdobeAcrobatPro/AdobeAcrobatProUpdateInfoProvider.py
+++ b/AdobeAcrobatPro/AdobeAcrobatProUpdateInfoProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for AdobeAcrobatProUpdateInfoProvider class"""
 
+from __future__ import absolute_import
 import urllib2
 import re
 

--- a/AdobeAcrobatPro/AdobeAcrobatProUpdateInfoProvider.py
+++ b/AdobeAcrobatPro/AdobeAcrobatProUpdateInfoProvider.py
@@ -16,11 +16,16 @@
 """See docstring for AdobeAcrobatProUpdateInfoProvider class"""
 
 from __future__ import absolute_import
-import urllib2
+
 import re
+from plistlib import readPlistFromString
 
 from autopkglib import Processor, ProcessorError
-from plistlib import readPlistFromString
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["AdobeAcrobatProUpdateInfoProvider"]
 
@@ -117,7 +122,7 @@ class AdobeAcrobatProUpdateInfoProvider(Processor):
         '''Get data from a url'''
         #pylint: disable=no-self-use
         try:
-            url_handle = urllib2.urlopen(url)
+            url_handle = urlopen(url)
             response = url_handle.read()
             url_handle.close()
         except BaseException as err:

--- a/AdobeFlashPlayer/AdobeFlashDmgUnpacker.py
+++ b/AdobeFlashPlayer/AdobeFlashDmgUnpacker.py
@@ -20,15 +20,15 @@
 ###
 
 from __future__ import absolute_import
+
 import os
-import FoundationPlist
-import tempfile
 import shutil
 import subprocess
+import tempfile
 
-from autopkglib.PkgExtractor import PkgExtractor
+import FoundationPlist
 from autopkglib import ProcessorError
-
+from autopkglib.PkgExtractor import PkgExtractor
 
 __all__ = ["AdobeFlashDmgUnpacker"]
 

--- a/AdobeFlashPlayer/AdobeFlashDmgUnpacker.py
+++ b/AdobeFlashPlayer/AdobeFlashDmgUnpacker.py
@@ -19,6 +19,7 @@
 ### NOTE: this processor is no longer used as Adobe has fixed their package
 ###
 
+from __future__ import absolute_import
 import os
 import FoundationPlist
 import tempfile
@@ -96,7 +97,7 @@ class AdobeFlashDmgUnpacker(PkgExtractor):
             with open(patched_postflight_path, "wb") as fref:
                 fref.write(postflight.replace(
                     "/Library/Internet Plug-Ins", temp_path))
-            os.chmod(patched_postflight_path, 0700)
+            os.chmod(patched_postflight_path, 0o700)
 
             # Run patched postflight to unpack plugin.
             subprocess.check_call(patched_postflight_path)
@@ -123,7 +124,7 @@ class AdobeFlashDmgUnpacker(PkgExtractor):
         dest_app_path = os.path.join(
             dest_path, "Adobe Flash Player Install Manager.app")
         try:
-            os.makedirs(dest_path, 0755)
+            os.makedirs(dest_path, 0o755)
             shutil.copytree(source_app_path, dest_app_path)
         except (OSError, IOError):
             raise ProcessorError(

--- a/AdobeFlashPlayer/AdobeFlashDownloadDecoder.py
+++ b/AdobeFlashPlayer/AdobeFlashDownloadDecoder.py
@@ -16,13 +16,12 @@
 """See docstring for AdobeFlashDownloadDecoder class"""
 
 from __future__ import absolute_import
+
 import os
 import subprocess
-
 from tempfile import mkstemp
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["AdobeFlashDownloadDecoder"]
 

--- a/AdobeFlashPlayer/AdobeFlashDownloadDecoder.py
+++ b/AdobeFlashPlayer/AdobeFlashDownloadDecoder.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for AdobeFlashDownloadDecoder class"""
 
+from __future__ import absolute_import
 import os
 import subprocess
 

--- a/AdobeFlashPlayer/AdobeFlashDownloadDecoder.py
+++ b/AdobeFlashPlayer/AdobeFlashDownloadDecoder.py
@@ -66,7 +66,7 @@ class AdobeFlashDownloadDecoder(Processor):
         try:
             subprocess.check_call([sec_bin, "create-keychain",
                                    "-p", "", keychain_file])
-        except Exception as exp:
+        except BaseException as exp:
             raise ProcessorError("Error creating temporary keychain at path "
                                  "%s: %s" % (keychain_file, exp))
 

--- a/AdobeFlashPlayer/AdobeFlashURLProvider.py
+++ b/AdobeFlashPlayer/AdobeFlashURLProvider.py
@@ -18,6 +18,7 @@
 # limitations under the License.
 """See docstring for AdobeFlashURLProvider class"""
 
+from __future__ import absolute_import
 import subprocess
 from xml.etree import ElementTree
 
@@ -92,7 +93,7 @@ class AdobeFlashURLProvider(Processor):
 
             try:
                 root = ElementTree.fromstring(xml_data)
-            except (OSError, IOError, ElementTree.ParseError), err:
+            except (OSError, IOError, ElementTree.ParseError) as err:
                 raise Exception("Can't read %s: %s" % (xml_data, err))
 
             # extract version number from the XML

--- a/AdobeFlashPlayer/AdobeFlashURLProvider.py
+++ b/AdobeFlashPlayer/AdobeFlashURLProvider.py
@@ -19,6 +19,7 @@
 """See docstring for AdobeFlashURLProvider class"""
 
 from __future__ import absolute_import
+
 import subprocess
 from xml.etree import ElementTree
 

--- a/AdobeReader/AdobeReaderRepackager.py
+++ b/AdobeReader/AdobeReaderRepackager.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for AdobeReaderRepackager class"""
 
+from __future__ import absolute_import
 import os
 import shutil
 import subprocess
@@ -99,13 +100,13 @@ class AdobeReaderRepackager(DmgMounter):
         if os.path.isdir(expand_dir):
             try:
                 shutil.rmtree(expand_dir)
-            except (OSError, IOError), err:
+            except (OSError, IOError) as err:
                 raise ProcessorError(
                     "Can't remove %s: %s" % (expand_dir, err))
         try:
             subprocess.check_call(
                 ['/usr/sbin/pkgutil', '--expand', pkg, expand_dir])
-        except subprocess.CalledProcessError, err:
+        except subprocess.CalledProcessError as err:
             raise ProcessorError("%s expanding %s" % (err, pkg))
         return expand_dir
 
@@ -115,13 +116,13 @@ class AdobeReaderRepackager(DmgMounter):
         if os.path.exists(destination):
             try:
                 os.unlink(destination)
-            except OSError, err:
+            except OSError as err:
                 raise ProcessorError(
                     "Can't remove %s: %s" % (destination, err))
         try:
             subprocess.check_call(
                 ['/usr/sbin/pkgutil', '--flatten', expanded_pkg, destination])
-        except subprocess.CalledProcessError, err:
+        except subprocess.CalledProcessError as err:
             raise ProcessorError(
                 "%s flattening %s" % (err, expanded_pkg))
 
@@ -134,7 +135,7 @@ class AdobeReaderRepackager(DmgMounter):
             raise ProcessorError("%s not found")
         try:
             dist = ElementTree.parse(dist_file)
-        except (OSError, IOError, ElementTree.ParseError), err:
+        except (OSError, IOError, ElementTree.ParseError) as err:
             raise ProcessorError("Can't read %s: %s" % (dist_file, err))
 
         dist_root = dist.getroot()
@@ -146,7 +147,7 @@ class AdobeReaderRepackager(DmgMounter):
             dist_root.remove(domains)
             try:
                 dist.write(dist_file)
-            except (OSError, IOError), err:
+            except (OSError, IOError) as err:
                 raise ProcessorError(
                     "Could not write %s: %s" % (dist_file, err))
 
@@ -169,11 +170,11 @@ class AdobeReaderRepackager(DmgMounter):
             raise ProcessorError("%s not found" % our_script)
         try:
             os.unlink(preinstall_script)
-        except (OSError, IOError), err:
+        except (OSError, IOError) as err:
             raise ProcessorError("%s removing %s" % (err, preinstall_script))
         try:
             shutil.copy(our_script, preinstall_script)
-        except (OSError, IOError), err:
+        except (OSError, IOError) as err:
             raise ProcessorError(
                 "%s copying %s to %s" % (err, our_script, preinstall_script))
         self.output(
@@ -198,7 +199,7 @@ class AdobeReaderRepackager(DmgMounter):
             self.flatten(expanded_pkg, modified_pkg)
             self.env["pkg_path"] = modified_pkg
 
-        except BaseException, err:
+        except BaseException as err:
             raise ProcessorError(err)
         finally:
             self.unmount(self.env["dmg_path"])

--- a/AdobeReader/AdobeReaderRepackager.py
+++ b/AdobeReader/AdobeReaderRepackager.py
@@ -16,14 +16,14 @@
 """See docstring for AdobeReaderRepackager class"""
 
 from __future__ import absolute_import
+
 import os
 import shutil
 import subprocess
 from xml.etree import ElementTree
 
-from autopkglib.DmgMounter import DmgMounter
 from autopkglib import ProcessorError
-
+from autopkglib.DmgMounter import DmgMounter
 
 __all__ = ["AdobeReaderRepackager"]
 

--- a/AdobeReader/AdobeReaderURLProvider.py
+++ b/AdobeReader/AdobeReaderURLProvider.py
@@ -17,11 +17,11 @@
 
 
 from __future__ import absolute_import
+
 import json
 import urllib2
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["AdobeReaderURLProvider"]
 
@@ -106,4 +106,3 @@ class AdobeReaderURLProvider(Processor):
 if __name__ == "__main__":
     PROCESSOR = AdobeReaderURLProvider()
     PROCESSOR.execute_shell()
-

--- a/AdobeReader/AdobeReaderURLProvider.py
+++ b/AdobeReader/AdobeReaderURLProvider.py
@@ -16,6 +16,7 @@
 """See docstring for AdobeReaderURLProvider class"""
 
 
+from __future__ import absolute_import
 import json
 import urllib2
 

--- a/AdobeReader/AdobeReaderUpdatesURLProvider.py
+++ b/AdobeReader/AdobeReaderUpdatesURLProvider.py
@@ -20,6 +20,7 @@
 #pylint: disable=e1101
 
 from __future__ import absolute_import
+
 import plistlib
 
 from autopkglib import Processor, ProcessorError

--- a/AdobeReader/AdobeReaderUpdatesURLProvider.py
+++ b/AdobeReader/AdobeReaderUpdatesURLProvider.py
@@ -19,6 +19,7 @@
 # specific processors.
 #pylint: disable=e1101
 
+from __future__ import absolute_import
 import urllib2
 import plistlib
 

--- a/AdobeReader/AdobeReaderUpdatesURLProvider.py
+++ b/AdobeReader/AdobeReaderUpdatesURLProvider.py
@@ -20,11 +20,14 @@
 #pylint: disable=e1101
 
 from __future__ import absolute_import
-import urllib2
 import plistlib
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["AdobeReaderUpdatesURLProvider"]
 
@@ -77,10 +80,8 @@ class AdobeReaderUpdatesURLProvider(Processor):
     def get_reader_updater_pkg_url(self, major_version):
         '''Returns download URL for Adobe Reader Updater DMG'''
 
-        request = urllib2.Request(
-            AR_UPDATER_BASE_URL + AR_MANIFEST_TEMPLATE % major_version)
         try:
-            url_handle = urllib2.urlopen(request)
+            url_handle = urlopen(AR_UPDATER_BASE_URL + AR_MANIFEST_TEMPLATE % major_version)
             version_string = url_handle.read()
             url_handle.close()
         except BaseException as err:
@@ -93,10 +94,8 @@ class AdobeReaderUpdatesURLProvider(Processor):
         version_string = version_string.replace(AR_PROD_IDENTIFIER, AR_PROD)
         version_string = version_string.replace(AR_PROD_ARCH_IDENTIFIER, AR_PROD_ARCH)
 
-        request = urllib2.Request(
-            AR_UPDATER_BASE_URL + version_string)
         try:
-            url_handle = urllib2.urlopen(request)
+            url_handle = urlopen(AR_UPDATER_BASE_URL + version_string)
             plist = plistlib.readPlistFromString(url_handle.read())
             url_handle.close()
         except BaseException as err:
@@ -108,10 +107,8 @@ class AdobeReaderUpdatesURLProvider(Processor):
     def get_reader_updater_dmg_url(self, major_version):
         '''Returns download URL for Adobe Reader Updater DMG'''
 
-        request = urllib2.Request(
-            AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
         try:
-            url_handle = urllib2.urlopen(request)
+            url_handle = urlopen(AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
             version_string = url_handle.read()
             url_handle.close()
         except BaseException as err:
@@ -122,10 +119,8 @@ class AdobeReaderUpdatesURLProvider(Processor):
         version_string = version_string.replace(OSX_MAJREV_IDENTIFIER, os_maj)
         version_string = version_string.replace(OSX_MINREV_IDENTIFIER, os_min)
 
-        request = urllib2.Request(
-            AR_UPDATER_BASE_URL + version_string)
         try:
-            url_handle = urllib2.urlopen(request)
+            url_handle = urlopen(AR_UPDATER_BASE_URL + version_string)
             version = url_handle.read()
             url_handle.close()
         except BaseException as err:

--- a/AutoPkg/AutoPkgSourceFinder.py
+++ b/AutoPkg/AutoPkgSourceFinder.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for AutoPkgSourceFinder class"""
 
+from __future__ import absolute_import
 import os
 import glob
 

--- a/AutoPkg/AutoPkgSourceFinder.py
+++ b/AutoPkg/AutoPkgSourceFinder.py
@@ -16,11 +16,11 @@
 """See docstring for AutoPkgSourceFinder class"""
 
 from __future__ import absolute_import
-import os
+
 import glob
+import os
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["AutoPkgSourceFinder"]
 

--- a/Barebones/BarebonesURLProvider.py
+++ b/Barebones/BarebonesURLProvider.py
@@ -72,12 +72,11 @@ class BarebonesURLProvider(Processor):
             '''compare LooseVersions'''
             return cmp(LooseVersion(this), LooseVersion(that))
 
-        valid_prods = URLS.keys()
         prod = self.env.get("product_name")
-        if prod not in valid_prods:
+        if prod not in URLS:
             raise ProcessorError(
                 "product_name %s is invalid; it must be one of: %s"
-                % (prod, valid_prods))
+                % (prod, ', '.join(URLS)))
         url = URLS[prod]
         try:
             manifest_str = urllib2.urlopen(url).read()

--- a/Barebones/BarebonesURLProvider.py
+++ b/Barebones/BarebonesURLProvider.py
@@ -17,6 +17,7 @@
 # suppress 'missing class member env'
 #pylint: disable=e1101
 
+from __future__ import absolute_import
 import urllib2
 import plistlib
 from distutils.version import LooseVersion

--- a/Barebones/BarebonesURLProvider.py
+++ b/Barebones/BarebonesURLProvider.py
@@ -18,20 +18,25 @@
 #pylint: disable=e1101
 
 from __future__ import absolute_import
-import urllib2
+
 import plistlib
+import ssl
 from distutils.version import LooseVersion
+from functools import wraps
 from operator import itemgetter
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["BarebonesURLProvider"]
 
 URLS = {"textwrangler": "https://versioncheck.barebones.com/TextWrangler.xml",
         "bbedit": "https://versioncheck.barebones.com/BBEdit.xml"}
 
-import ssl
-from functools import wraps
 def sslwrap(func):
     """http://stackoverflow.com/a/24175862"""
     @wraps(func)
@@ -79,7 +84,7 @@ class BarebonesURLProvider(Processor):
                 % (prod, ', '.join(URLS)))
         url = URLS[prod]
         try:
-            manifest_str = urllib2.urlopen(url).read()
+            manifest_str = urlopen(url).read()
         except BaseException as err:
             raise ProcessorError(
                 "Unexpected error retrieving product manifest: '%s'" % err)

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for MSOffice2011UpdateInfoProvider class"""
 
+from __future__ import absolute_import
 import plistlib
 import urllib2
 

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -167,6 +167,13 @@ class MSOffice2011UpdateInfoProvider(Processor):
     def value_to_os_version_string(self, value):
         """Converts a value to an OS X version number"""
         #pylint: disable=no-self-use
+
+        # Map string type for both Python 2 and Python 3.
+        try:
+            _ = basestring
+        except NameError:
+            basestring = str  # pylint: disable=W0622
+
         if isinstance(value, int):
             version_str = hex(value)[2:]
         elif isinstance(value, basestring):

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -250,15 +250,15 @@ class MSOffice2011UpdateInfoProvider(Processor):
         # Try to use https even though url is http
         download_url_scheme = self.env.get("download_url_scheme", DOWNLOAD_URL_SCHEME)
         if DOWNLOAD_URL_SCHEME == "https":
-        	try:
-        		pkg_url = item["Location"]
-        		https_url = list(urlparse(pkg_url))
-        		https_url[0] = 'https'
-        		self.env["url"] = urlunparse(https_url)
-        	except ValueError:
-        		self.env["url"] = item["Location"]
+            try:
+                pkg_url = item["Location"]
+                https_url = list(urlparse(pkg_url))
+                https_url[0] = 'https'
+                self.env["url"] = urlunparse(https_url)
+            except ValueError:
+                self.env["url"] = item["Location"]
         else:
-        	self.env["url"] = item["Location"]
+            self.env["url"] = item["Location"]
         self.env["pkg_name"] = item["Payload"]
         self.env["version"] = self.get_version(item)
         self.output("Found URL %s" % self.env["url"])

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -16,15 +16,14 @@
 """See docstring for MSOffice2011UpdateInfoProvider class"""
 
 from __future__ import absolute_import
+
 import plistlib
 import urllib2
-
 from distutils.version import LooseVersion
 from operator import itemgetter
 from urlparse import urlparse, urlunparse
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["MSOffice2011UpdateInfoProvider"]
 

--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -20,12 +20,12 @@
 """See docstring for MSOfficeMacURLandUpdateInfoProvider class"""
 
 from __future__ import absolute_import
+
 import plistlib
 import re
 import urllib2
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["MSOfficeMacURLandUpdateInfoProvider"]
 

--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -116,7 +116,7 @@ class MSOfficeMacURLandUpdateInfoProvider(Processor):
                  "Defaults to %s, acceptable values are either a custom "
                  "UUID or one of: %s" % (
                     DEFAULT_CHANNEL,
-                    ", ".join(CHANNELS.keys())))
+                    ", ".join(CHANNELS)))
         }
     }
     output_variables = {
@@ -198,10 +198,10 @@ class MSOfficeMacURLandUpdateInfoProvider(Processor):
         channel_input = self.env.get("channel", DEFAULT_CHANNEL)
         rex = r"^([0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})$"
         match_uuid = re.match(rex, channel_input)
-        if not match_uuid and channel_input not in CHANNELS.keys():
+        if not match_uuid and channel_input not in CHANNELS:
             raise ProcessorError(
                 "'channel' input variable must be one of: %s or a custom "
-                "uuid" % (", ".join(CHANNELS.keys())))
+                "uuid" % (", ".join(CHANNELS)))
         if match_uuid:
             channel = match_uuid.groups()[0]
         else:
@@ -271,7 +271,7 @@ class MSOfficeMacURLandUpdateInfoProvider(Processor):
                 "Locale ID %s not found in manifest metadata. Available IDs: "
                 "%s. See %s for more details." % (
                     lcid,
-                    ", ".join(all_localizations.keys()),
+                    ", ".join(all_localizations),
                     LOCALE_ID_INFO_URL))
         manifest_description = all_localizations[lcid]['Short Description']
         # Store the description in a separate output variable and in our pkginfo

--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -19,6 +19,7 @@
 #pylint:disable=e1101
 """See docstring for MSOfficeMacURLandUpdateInfoProvider class"""
 
+from __future__ import absolute_import
 import plistlib
 import re
 import urllib2
@@ -34,10 +35,10 @@ CULTURE_CODE = "0409"
 BASE_URL = "https://officecdn.microsoft.com/pr/%s/MacAutoupdate/%s.xml"
 
 # These can be easily be found as "Application ID" in
-# ~/Library/Preferences/com.microsoft.autoupdate2.plist on a 
+# ~/Library/Preferences/com.microsoft.autoupdate2.plist on a
 # machine that has Microsoft AutoUpdate.app installed on it.
 #
-# Note that Skype, 'MSFB' has a '16' after it, 
+# Note that Skype, 'MSFB' has a '16' after it,
 # AutoUpdate has a '03' or '04' after it,
 # other Office 2016 products have '15'; Office 2019/365 prodects end with 2019
 
@@ -244,7 +245,7 @@ class MSOfficeMacURLandUpdateInfoProvider(Processor):
         # is not guaranteed to be the "latest" delta. Does anybody actually
         # use this?
         item = item[0]
-        
+
         if self.env["version"] == "latest-standalone":
             # do string replacement on the pattern of the URL in the
             # case of a Standalone app request.

--- a/Mozilla/MozillaURLProvider.py
+++ b/Mozilla/MozillaURLProvider.py
@@ -16,8 +16,8 @@
 """See docstring for MozillaURLProvider class"""
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["MozillaURLProvider"]
 
@@ -103,4 +103,3 @@ class MozillaURLProvider(Processor):
 if __name__ == "__main__":
     PROCESSOR = MozillaURLProvider()
     PROCESSOR.execute_shell()
-

--- a/Mozilla/MozillaURLProvider.py
+++ b/Mozilla/MozillaURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for MozillaURLProvider class"""
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 

--- a/Munki/MakeCatalogsProcessor.py
+++ b/Munki/MakeCatalogsProcessor.py
@@ -16,6 +16,7 @@
 """autopkg processor to run makecatalogs on a Munki repo"""
 
 from __future__ import absolute_import
+
 import os.path
 import plistlib
 import subprocess
@@ -115,4 +116,3 @@ class MakeCatalogsProcessor(Processor):
 if __name__ == "__main__":
     PROCESSOR = MakeCatalogsProcessor()
     PROCESSOR.execute_shell()
-

--- a/Munki/MakeCatalogsProcessor.py
+++ b/Munki/MakeCatalogsProcessor.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """autopkg processor to run makecatalogs on a Munki repo"""
 
+from __future__ import absolute_import
 import os.path
 import plistlib
 import subprocess

--- a/Praat/PraatURLProvider.py
+++ b/Praat/PraatURLProvider.py
@@ -17,10 +17,13 @@
 
 from __future__ import absolute_import
 import re
-import urllib2
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["PraatURLProvider"]
 
@@ -56,7 +59,7 @@ class PraatURLProvider(Processor):
         re_praat_dmg = re.compile(PRAAT_DMG_RE.format(arch))
         # Read HTML index.
         try:
-            fref = urllib2.urlopen(base_url)
+            fref = urlopen(base_url)
             html = fref.read()
             fref.close()
         except BaseException as err:

--- a/Praat/PraatURLProvider.py
+++ b/Praat/PraatURLProvider.py
@@ -16,6 +16,7 @@
 """See docstring for PraatURLProvider class"""
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/Praat/PraatURLProvider.py
+++ b/Praat/PraatURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for PraatURLProvider class"""
 
+from __future__ import absolute_import
 import re
 import urllib2
 

--- a/Praat/PraatVersionFixer.py
+++ b/Praat/PraatVersionFixer.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for PraatVersionFixer class"""
 
+from __future__ import absolute_import
 import os.path
 #pylint: disable=no-name-in-module
 from Foundation import NSData, \

--- a/Praat/PraatVersionFixer.py
+++ b/Praat/PraatVersionFixer.py
@@ -16,15 +16,20 @@
 """See docstring for PraatVersionFixer class"""
 
 from __future__ import absolute_import
+
 import os.path
-#pylint: disable=no-name-in-module
-from Foundation import NSData, \
-                       NSPropertyListSerialization, \
-                       NSPropertyListXMLFormat_v1_0, \
-                       NSPropertyListMutableContainers
-#pylint: enable=no-name-in-module
 
 from autopkglib import Processor, ProcessorError
+#pylint: disable=no-name-in-module
+from Foundation import (
+    NSData,
+    NSPropertyListMutableContainers,
+    NSPropertyListSerialization,
+    NSPropertyListXMLFormat_v1_0,
+)
+
+#pylint: enable=no-name-in-module
+
 
 
 __all__ = ["PraatVersionFixer"]

--- a/Puppetlabs/PuppetlabsProductsURLProvider.py
+++ b/Puppetlabs/PuppetlabsProductsURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for PuppetlabsProductsURLProvider class"""
 
+from __future__ import absolute_import
 import urllib2
 import re
 from distutils.version import LooseVersion

--- a/Puppetlabs/PuppetlabsProductsURLProvider.py
+++ b/Puppetlabs/PuppetlabsProductsURLProvider.py
@@ -16,6 +16,7 @@
 """See docstring for PuppetlabsProductsURLProvider class"""
 
 from __future__ import absolute_import
+
 import re
 from distutils.version import LooseVersion
 

--- a/Puppetlabs/PuppetlabsProductsURLProvider.py
+++ b/Puppetlabs/PuppetlabsProductsURLProvider.py
@@ -16,11 +16,15 @@
 """See docstring for PuppetlabsProductsURLProvider class"""
 
 from __future__ import absolute_import
-import urllib2
 import re
 from distutils.version import LooseVersion
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["PuppetlabsProductsURLProvider"]
 
@@ -82,7 +86,7 @@ class PuppetlabsProductsURLProvider(Processor):
                            % (self.env["product_name"].lower(), version_re))
 
         try:
-            data = urllib2.urlopen(download_url).read()
+            data = urlopen(download_url).read()
         except BaseException as err:
             raise ProcessorError(
                 "Unexpected error retrieving download index: '%s'" % err)

--- a/SampleSharedProcessor/SampleSharedProcessor.py
+++ b/SampleSharedProcessor/SampleSharedProcessor.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for SampleSharedProcessor class"""
 
+from __future__ import absolute_import
 import os
 from autopkglib import Processor, ProcessorError
 

--- a/SampleSharedProcessor/SampleSharedProcessor.py
+++ b/SampleSharedProcessor/SampleSharedProcessor.py
@@ -16,7 +16,9 @@
 """See docstring for SampleSharedProcessor class"""
 
 from __future__ import absolute_import
+
 import os
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["SampleSharedProcessor"]

--- a/SassafrasK2Client/SassafrasK2ClientCustomizer.py
+++ b/SassafrasK2Client/SassafrasK2ClientCustomizer.py
@@ -16,6 +16,7 @@
 """See docstring for SassafrasK2ClientCustomizer class"""
 
 
+from __future__ import absolute_import
 import os
 import subprocess
 
@@ -59,7 +60,7 @@ class SassafrasK2ClientCustomizer(Processor):
             raise ProcessorError("No file exists at k2clientconfig_path: "
                                  "%s" % script)
         if not os.access(script, os.X_OK):
-            os.chmod(script, 0755)
+            os.chmod(script, 0o755)
         if not os.path.exists(pkg):
             raise ProcessorError("No K2Client pkg exists at "
                                  "base_pkg_path: %s" % pkg)

--- a/SassafrasK2Client/SassafrasK2ClientCustomizer.py
+++ b/SassafrasK2Client/SassafrasK2ClientCustomizer.py
@@ -17,11 +17,11 @@
 
 
 from __future__ import absolute_import
+
 import os
 import subprocess
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["SassafrasK2ClientCustomizer"]
 

--- a/TextMate/TextMateURLProvider.py
+++ b/TextMate/TextMateURLProvider.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """See docstring for TextMateURLProvider processor"""
 
+from __future__ import absolute_import
+from __future__ import print_function
 from subprocess import Popen, PIPE
 from autopkglib import Processor, ProcessorError
 
@@ -59,7 +61,7 @@ class TextMateURLProvider(Processor):
         out, err = proc.communicate()
         parsed_url = None
         if err:
-            print err
+            print(err)
             raise ProcessorError("curl returned an error: %s" % out)
         for line in out.splitlines():
             if line.startswith("Location"):

--- a/TextMate/TextMateURLProvider.py
+++ b/TextMate/TextMateURLProvider.py
@@ -15,9 +15,10 @@
 # limitations under the License.
 """See docstring for TextMateURLProvider processor"""
 
-from __future__ import absolute_import
-from __future__ import print_function
-from subprocess import Popen, PIPE
+from __future__ import absolute_import, print_function
+
+from subprocess import PIPE, Popen
+
 from autopkglib import Processor, ProcessorError
 
 DEFAULT_BRANCH = "release"


### PR DESCRIPTION
In order to make our processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including handling HTTP headers and the `cmp()` builtin), but this should catch the low-hanging fruit right now.