### PR TITLE
Remove TextWrangler from provider

### DIFF
--- a/Barebones/BarebonesURLProvider.py
+++ b/Barebones/BarebonesURLProvider.py
@@ -34,8 +34,7 @@ except ImportError:
 
 __all__ = ["BarebonesURLProvider"]
 
-URLS = {"textwrangler": "https://versioncheck.barebones.com/TextWrangler.xml",
-        "bbedit": "https://versioncheck.barebones.com/BBEdit.xml"}
+URLS = {"bbedit": "https://versioncheck.barebones.com/BBEdit.xml"}
 
 def sslwrap(func):
     """http://stackoverflow.com/a/24175862"""


### PR DESCRIPTION
No further updates to TextWrangler are planned. Details: http://www.barebones.com/products/textwrangler/

(Related: There is a Yojimbo feed available and I thought briefly about adding that to the provider, but it looks like Yojimbo also hasn't been updated in years.)