### PR TITLE
Recipes that use the newly signed Firefox 69.0 package

### DIFF
--- a/Mozilla/Firefox.download.recipe
+++ b/Mozilla/Firefox.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download recipe for Firefox. Finds and downloads a Firefox release.
+    <string>Download recipe for Firefox. Finds and downloads a Firefox release disk image.
 Some useful values for RELEASE are: 'latest', 'esr-latest', 'beta-latest'.
 LOCALE controls the language localization to be downloded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'

--- a/Mozilla/FirefoxSignedPkg.download.recipe
+++ b/Mozilla/FirefoxSignedPkg.download.recipe
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>This recipe downloads the signed installer package that Mozilla made available starting in Firefox 69.0.
+
+The RELEASE key used in the standard Firefox recipes are not yet supported.
+LOCALE controls the language localization to be downloded.
+Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
+See the following URL for possible LOCALE values:
+    http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt
+</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.download.FirefoxSignedPkg</string>
+	<key>Input</key>
+	<dict>
+		<key>LOCALE</key>
+		<string>en-US</string>
+		<key>NAME</key>
+		<string>Firefox</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>data-latest-firefox="([\d\.]+)"</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+				<key>url</key>
+				<string>https://www.mozilla.org/firefox/download/thanks/</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.pkg</string>
+				<key>url</key>
+				<string>http://releases.mozilla.org/pub/firefox/releases/%version%/mac/%LOCALE%/Firefox%20%version%.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authorities</key>
+				<array>
+					<string>Developer ID Installer: Mozilla Corporation (43AQ936H96)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Mozilla/FirefoxSignedPkg.download.recipe
+++ b/Mozilla/FirefoxSignedPkg.download.recipe
@@ -28,11 +28,11 @@ See the following URL for possible LOCALE values:
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>data-latest-firefox="([\d\.]+)"</string>
+				<string>"LATEST_FIREFOX_VERSION": "([\d\.]+)"</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 				<key>url</key>
-				<string>https://www.mozilla.org/firefox/download/thanks/</string>
+				<string>https://product-details.mozilla.org/1.0/firefox_versions.json</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Mozilla/FirefoxSignedPkg.install.recipe
+++ b/Mozilla/FirefoxSignedPkg.install.recipe
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>This recipe downloads the signed installer package that Mozilla made available starting in Firefox 69.0, and installs it locally onto the computer running AutoPkg.
+
+The RELEASE key used in the standard Firefox recipes are not yet supported.
+LOCALE controls the language localization to be downloded.
+Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
+See the following URL for possible LOCALE values:
+    http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt
+</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.install.FirefoxSignedPkg</string>
+	<key>Input</key>
+	<dict>
+		<key>RELEASE</key>
+		<string>latest</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.download.FirefoxSignedPkg</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>Installer</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Mozilla/FirefoxSignedPkg.munki.recipe
+++ b/Mozilla/FirefoxSignedPkg.munki.recipe
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>This recipe downloads the signed installer package that Mozilla made available starting in Firefox 69.0, and imports the pkg file into a Munki repo.
+
+The RELEASE key used in the standard Firefox recipes are not yet supported.
+LOCALE controls the language localization to be downloded.
+Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
+See the following URL for possible LOCALE values:
+    http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt
+</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.munki.FirefoxSignedPkg</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/firefox</string>
+		<key>NAME</key>
+		<string>Firefox</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>blocking_applications</key>
+			<array>
+				<string>Firefox.app</string>
+			</array>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Mozilla Firefox is a free and open source web browser.</string>
+			<key>display_name</key>
+			<string>Mozilla Firefox</string>
+			<key>minimum_os_version</key>
+			<string>10.9</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.download.FirefoxSignedPkg</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Mozilla/FirefoxSignedPkg.pkg.recipe
+++ b/Mozilla/FirefoxSignedPkg.pkg.recipe
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>This recipe downloads the signed installer package that Mozilla made available starting in Firefox 69.0. Because the downloaded file is already a package, this pkg recipe does not add any further actions.
+
+The RELEASE key used in the standard Firefox recipes are not yet supported.
+LOCALE controls the language localization to be downloded.
+Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
+See the following URL for possible LOCALE values:
+    http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt
+</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.pkg.FirefoxSignedPkg</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Firefox</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.download.FirefoxSignedPkg</string>
+	<key>Process</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
Verbose output: https://gist.github.com/homebysix/fd8aaecc49dfdba24485692485d60dd6

Tested with the 'en-US', 'de', 'sv-SE', and 'zh-TW' locales successfully.