### PR TITLE
Add "os" parameter for TextMateURLProvider

### DIFF
--- a/TextMate/TextMate2.download.recipe
+++ b/TextMate/TextMate2.download.recipe
@@ -17,6 +17,8 @@ preferences panel.
         <string>TextMate2</string>
         <key>BRANCH</key>
         <string>release</string>
+        <key>OS</key>
+        <string>10.14</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.0</string>
@@ -29,6 +31,8 @@ preferences panel.
             <dict>
                 <key>branch</key>
                 <string>%BRANCH%</string>
+                <key>os</key>
+                <string>%OS%</string>
             </dict>
         </dict>
         <dict>

--- a/TextMate/TextMate2.munki.recipe
+++ b/TextMate/TextMate2.munki.recipe
@@ -35,6 +35,8 @@ preferences panel.
             <string>TextMate brings Apple&apos;s approach to operating systems into the world of text editors. By bridging UNIX underpinnings and GUI, TextMate cherry-picks the best of both worlds to the benefit of expert scripters and novice users alike.</string>
             <key>display_name</key>
             <string>TextMate 2</string>
+            <key>minimum_os_version</key>
+            <string>10.12</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>postinstall_script</key>

--- a/TextMate/TextMate2.munki.recipe
+++ b/TextMate/TextMate2.munki.recipe
@@ -23,6 +23,8 @@ preferences panel.
         <string>TextMate2</string>
         <key>BRANCH</key>
         <string>release</string>
+        <key>OS</key>
+        <string>10.14</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>

--- a/TextMate/TextMateURLProvider.py
+++ b/TextMate/TextMateURLProvider.py
@@ -22,6 +22,7 @@ from subprocess import PIPE, Popen
 from autopkglib import Processor, ProcessorError
 
 DEFAULT_BRANCH = "release"
+DEFAULT_OS = "10.14"
 BASE_URL = "https://api.textmate.org/downloads/"
 
 # Another interesting URL that returns an ASCII-style plist used by
@@ -35,6 +36,7 @@ __all__ = ["TextMateURLProvider"]
 class TextMateURLProvider(Processor):
     """Provides a download URL for a TextMate 2 update.
     TextMate 1 is not supported."""
+
     description = __doc__
     input_variables = {
         "branch": {
@@ -42,23 +44,30 @@ class TextMateURLProvider(Processor):
             "description": (
                 "The update branch. One of 'release', 'beta', or 'nightly'. "
                 "In the TM GUI, 'Normal' corresponds to 'release', 'Nightly' = "
-                "'beta'. Defaults to %s" % DEFAULT_BRANCH)
-        }
+                "'beta'. Defaults to %s" % DEFAULT_BRANCH
+            ),
+        },
+        "os": {
+            "required": False,
+            "description": (
+                "The macOS version you're requesting TextMate for use on. "
+                "Defaults to %s" % DEFAULT_OS
+            ),
+        },
     }
-    output_variables = {
-        "url": {
-            "description": "URL to the latest TextMate 2 tbz.",
-        }
-    }
+    output_variables = {"url": {"description": "URL to the latest TextMate 2 tbz."}}
 
     def main(self):
         url = BASE_URL + self.env.get("branch", DEFAULT_BRANCH)
+        os = self.env.get("os", DEFAULT_OS)
         # Using curl to fetch Location header(s) because urllib/2
         # cannot verify the SSL cert and the server won't accept this
         # TextMate's SSL hostnames don't seem to match the SSL cert name,
         # depending on the CA bundle being used. This can be verified
         # using the 'requests' Python library.
-        proc = Popen(['/usr/bin/curl', '-ILs', url], stdout=PIPE, stderr=PIPE)
+        proc = Popen(
+            ["/usr/bin/curl", "-ILs", url + "?os=" + os], stdout=PIPE, stderr=PIPE
+        )
         out, err = proc.communicate()
         parsed_url = None
         if err:
@@ -70,9 +79,11 @@ class TextMateURLProvider(Processor):
         if not parsed_url:
             raise ProcessorError(
                 "curl didn't find a resolved 'Location' header we can use. "
-                "Full curl output:\n %s" % "\n".join(out.splitlines()))
+                "Full curl output:\n %s" % "\n".join(out.splitlines())
+            )
 
         self.env["url"] = parsed_url
+
 
 if __name__ == "__main__":
     PROCESSOR = TextMateURLProvider()


### PR DESCRIPTION
TextMate 2.0 (non-release candidate) is [out](https://github.com/textmate/textmate/tree/v2.0). The URL scheme for the API now includes an `os` parameter, which needs to be one of `10.12`, `10.13`, `10.14` or `10.15` in order to download the latest version.

Verbose output confirming the processor is working as expected:
https://gist.github.com/homebysix/c79da6310124f7c7ca2d25cc2a44a5d4