### PR TITLE
Py23 compatibility for custom processors with URLGetter

### DIFF
--- a/AdobeReader/AdobeReaderURLProvider.py
+++ b/AdobeReader/AdobeReaderURLProvider.py
@@ -15,18 +15,12 @@
 # limitations under the License.
 """See docstring for AdobeReaderURLProvider class"""
 
-
-from __future__ import absolute_import
-
 import json
-import urllib.error
-import urllib.parse
-import urllib.request
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import ProcessorError
+from autopkglib.URLGetter import URLGetter
 
 __all__ = ["AdobeReaderURLProvider"]
-
 
 AR_BASE_URL = (
     "http://get.adobe.com/reader/webservices/json/standalone/"
@@ -41,7 +35,7 @@ OS_VERSION_DEFAULT = "10.8.0"
 MAJOR_VERSION_MATCH_STR = "adobe/reader/mac/%s"
 
 
-class AdobeReaderURLProvider(Processor):
+class AdobeReaderURLProvider(URLGetter):
     """Provides URL to the latest Adobe Reader release."""
 
     description = __doc__
@@ -75,16 +69,10 @@ class AdobeReaderURLProvider(Processor):
 
     def get_reader_dmg_url(self, base_url, language, major_version, os_version):
         """Returns download URL for Adobe Reader DMG"""
-        # pylint: disable=no-self-use
         request_url = base_url % (os_version, language)
-        request = urllib.request.Request(request_url)
-        request.add_header("x-requested-with", "XMLHttpRequest")
-        try:
-            url_handle = urllib.request.urlopen(request)
-            json_response = url_handle.read()
-            url_handle.close()
-        except Exception as err:
-            raise ProcessorError("Can't open %s: %s" % (base_url, err))
+        header = {"x-requested-with": "XMLHttpRequest"}
+        json_response = self.download(request_url, headers=header)
+
         reader_info = json.loads(json_response)
         major_version_string = MAJOR_VERSION_MATCH_STR % major_version
         matches = [

--- a/Barebones/BarebonesURLProvider.py
+++ b/Barebones/BarebonesURLProvider.py
@@ -16,11 +16,9 @@
 """See docstring for BarebonesURLProvider class"""
 
 from distutils.version import LooseVersion
-from operator import itemgetter
 
 from autopkglib import ProcessorError
 from autopkglib.URLGetter import URLGetter
-from past.builtins import cmp
 
 try:
     from plistlib import readPlistFromString
@@ -53,10 +51,6 @@ class BarebonesURLProvider(URLGetter):
     def main(self):
         """Find the download URL"""
 
-        def compare_version(this, that):
-            """compare LooseVersions"""
-            return cmp(LooseVersion(this), LooseVersion(that))
-
         prod = self.env.get("product_name")
         if prod not in URLS:
             raise ProcessorError(
@@ -78,9 +72,7 @@ class BarebonesURLProvider(URLGetter):
             raise ProcessorError("Expected 'SUFeedEntries' manifest key wasn't found.")
 
         sorted_entries = sorted(
-            entries,
-            key=itemgetter("SUFeedEntryShortVersionString"),
-            cmp=compare_version,
+            entries, key=lambda a: LooseVersion(a["SUFeedEntryShortVersionString"])
         )
         metadata = sorted_entries[-1]
         url = metadata["SUFeedEntryDownloadURL"]

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -17,12 +17,10 @@
 
 from builtins import hex
 from distutils.version import LooseVersion
-from operator import itemgetter
-from urllib.parse import urlparse, urlunparse
 
 from autopkglib import ProcessorError
 from autopkglib.URLGetter import URLGetter
-from past.builtins import basestring, cmp
+from past.builtins import basestring
 
 try:
     from urlparse import urlparse, urlunparse
@@ -131,10 +129,6 @@ class MSOffice2011UpdateInfoProvider(URLGetter):
         """Attempts to determine what earlier updates are
         required by this update"""
 
-        def compare_versions(this, that):
-            """Internal comparison function for use with sorting"""
-            return cmp(LooseVersion(this), LooseVersion(that))
-
         self.sanity_check_expected_triggers(item)
         munki_update_name = self.env.get("munki_update_name", MUNKI_UPDATE_NAME)
         mcp_versions = item.get("Triggers", {}).get("MCP", {}).get("Versions", [])
@@ -142,7 +136,7 @@ class MSOffice2011UpdateInfoProvider(URLGetter):
             return None
         # Versions array is already sorted in current 0409MSOf14.xml,
         # may be no need to sort; but we should just to be safe...
-        mcp_versions.sort(compare_versions)
+        mcp_versions = sorted(mcp_versions, key=lambda a: LooseVersion(a))
         if mcp_versions[0] == "14.0.0":
             # works with original Office release, so no requires array
             return None
@@ -237,7 +231,7 @@ class MSOffice2011UpdateInfoProvider(URLGetter):
         if version_str == "latest":
             # Office 2011 update metadata is a list of dicts.
             # we need to sort by date.
-            sorted_metadata = sorted(metadata, key=itemgetter("Date"))
+            sorted_metadata = sorted(metadata, key=lambda a: a["Date"])
             # choose the last item, which should be most recent.
             item = sorted_metadata[-1]
         else:

--- a/Munki/MakeCatalogsProcessor.py
+++ b/Munki/MakeCatalogsProcessor.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 """autopkg processor to run makecatalogs on a Munki repo"""
 
-from __future__ import absolute_import
-
 import os.path
 import plistlib
 import subprocess
@@ -62,7 +60,7 @@ class MakeCatalogsProcessor(Processor):
             cache_dir, "autopkg_results.plist")
         try:
             run_results = plistlib.readPlist(current_run_results_plist)
-        except IOError:
+        except (IOError, OSError):
             run_results = []
 
         something_imported = False
@@ -106,9 +104,10 @@ class MakeCatalogsProcessor(Processor):
                     % (err.errno, err.strerror))
 
             self.env["makecatalogs_resultcode"] = proc.returncode
-            self.env["makecatalogs_stderr"] = err_out
+            self.env["makecatalogs_stderr"] = err_out.decode("utf-8")
             if proc.returncode != 0:
-                raise ProcessorError("makecatalogs failed: %s" % err_out)
+                error_text = "makecatalogs failed: \n" + self.env["makecatalogs_stderr"]
+                raise ProcessorError(error_text)
             else:
                 self.output("Munki catalogs rebuilt!")
 

--- a/Praat/PraatURLProvider.py
+++ b/Praat/PraatURLProvider.py
@@ -15,20 +15,10 @@
 # limitations under the License.
 """See docstring for PraatURLProvider class"""
 
-from __future__ import absolute_import
-
 import re
 
-from autopkglib import Processor, ProcessorError
-from future import standard_library
-
-standard_library.install_aliases()
-
-
-try:
-    from urllib.parse import urlopen  # For Python 3
-except ImportError:
-    from urllib.request import urlopen  # For Python 2
+from autopkglib import ProcessorError
+from autopkglib.URLGetter import URLGetter
 
 __all__ = ["PraatURLProvider"]
 
@@ -38,7 +28,7 @@ PRAAT_DEFAULT_ARCH = "32"
 PRAAT_DMG_RE = r'a href="?(?P<url>praat\d+_mac{0}\.dmg)"?'
 
 
-class PraatURLProvider(Processor):
+class PraatURLProvider(URLGetter):
     """Provides URL to the latest release of Praat."""
 
     description = __doc__
@@ -62,12 +52,7 @@ class PraatURLProvider(Processor):
         arch = self.env.get("arch_edition", "32")
         re_praat_dmg = re.compile(PRAAT_DMG_RE.format(arch))
         # Read HTML index.
-        try:
-            fref = urlopen(base_url)
-            html = fref.read()
-            fref.close()
-        except Exception as err:
-            raise ProcessorError("Can't download %s: %s" % (base_url, err))
+        html = self.download(base_url, text=True)
 
         # Search for download link.
         match = re_praat_dmg.search(html)

--- a/Puppetlabs/PuppetlabsProductsURLProvider.py
+++ b/Puppetlabs/PuppetlabsProductsURLProvider.py
@@ -15,22 +15,12 @@
 # limitations under the License.
 """See docstring for PuppetlabsProductsURLProvider class"""
 
-from __future__ import absolute_import
-
 import re
 from builtins import str
 from distutils.version import LooseVersion
 
-from autopkglib import Processor, ProcessorError
-from future import standard_library
-
-standard_library.install_aliases()
-
-
-try:
-    from urllib.parse import urlopen  # For Python 3
-except ImportError:
-    from urllib.request import urlopen  # For Python 2
+from autopkglib import ProcessorError
+from autopkglib.URLGetter import URLGetter
 
 __all__ = ["PuppetlabsProductsURLProvider"]
 
@@ -39,7 +29,7 @@ DEFAULT_VERSION = "latest"
 OS_VERSION = "10.10"
 
 
-class PuppetlabsProductsURLProvider(Processor):
+class PuppetlabsProductsURLProvider(URLGetter):
     """Extracts a URL for a Puppet Labs item."""
 
     description = __doc__
@@ -95,14 +85,7 @@ class PuppetlabsProductsURLProvider(Processor):
                 self.env["product_name"].lower(),
                 version_re,
             )
-
-        try:
-            data = urlopen(download_url).read()
-        except Exception as err:
-            raise ProcessorError(
-                "Unexpected error retrieving download index: '%s'" % err
-            )
-
+        data = self.download(download_url, text=True)
         # (dmg, version)
         candidates = re.findall(re_download, data)
         if not candidates:


### PR DESCRIPTION
**This branch uses `URLGetter` which hasn't been relased yet**. Purpose of this PR is to make custom processors:

1. compatible with both Python 2 and Python3
2. (those useing `urllib`) subclasses `URLGetter`  and use share code.

More changes:

- Applied some python improvements from py2-to-3 branch
