### PR TITLE
Fix Praat download

### DIFF
--- a/Praat/Praat.download.recipe
+++ b/Praat/Praat.download.recipe
@@ -29,7 +29,7 @@ causing the CodeSignatureVerifier step to fail and print a warning.</string>
 				<key>re_pattern</key>
 				<string>a href="?(praat\d+_mac%ARCH_EDITION%.dmg)"?</string>
 				<key>result_output_var_name</key>
-				<string>filename</string>
+				<string>download_path</string>
 				<key>url</key>
 				<string>http://www.fon.hum.uva.nl/praat/download_mac.html</string>
 			</dict>
@@ -42,7 +42,7 @@ causing the CodeSignatureVerifier step to fail and print a warning.</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>http://www.fon.hum.uva.nl/praat/%filename%</string>
+				<string>http://www.fon.hum.uva.nl/praat/%download_path%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
filename was being set then overridden in the urldownloader and the file was 404-ing because it wasn't looking for the file we previously found. Changed the var so it wouldn't be overridden.

```
`{'Output': {u'filename': 'praat6108_mac64.dmg'}}
URLDownloader
{'Input': {'CURL_PATH': '/usr/bin/curl',
           'filename': u'Praat.dmg',
           'url': u'http://www.fon.hum.uva.nl/praat/Praat.dmg'}}
```
the URL _should_ be `http://www.fon.hum.uva.nl/praat/praat6108_mac64.dmg`