### PR TITLE
Change VLC appcast_url from http to https

### DIFF
--- a/VLC/VLC.download.recipe
+++ b/VLC/VLC.download.recipe
@@ -26,7 +26,7 @@ version 2.1.0. For this reason, the appcast_url variable is now hardcoded in the
             <key>Arguments</key>
             <dict>
                 <key>appcast_url</key>
-                <string>http://update.videolan.org/vlc/sparkle/vlc-intel64.xml</string>
+                <string>https://update.videolan.org/vlc/sparkle/vlc-intel64.xml</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Same file is also served over HTTPS (and will stop `autopkg audit` from complaining).