### PR TITLE
Added sort_by_highest_tag_names

### DIFF
--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -29,6 +29,8 @@ i.e.: `-k PRERELEASE=yes`</string>
                 <string>HandBrake/HandBrake</string>
                 <key>include_prereleases</key>
                 <string>%PRERELEASE%</string>
+                <key>sort_by_highest_tag_names</key>
+                <string>True</string>
                 <key>asset_regex</key>
                 <string>HandBrake-\S.*?.dmg</string>
             </dict>


### PR DESCRIPTION
Added sort_by_highest_tag_names to GitHubReleasesInfoProvider to avoid downloading older releases if they get modified (like 0.9.4)