### PR TITLE
Update GoogleChromePkg.pkg.recipe

### DIFF
--- a/GoogleChrome/GoogleChromePkg.pkg.recipe
+++ b/GoogleChrome/GoogleChromePkg.pkg.recipe
@@ -50,15 +50,13 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>Copier</string>
+            <string>PkgCopier</string>
             <key>Arguments</key>
             <dict>
-                <key>source_path</key>
+                <key>source_pkg</key>
                 <string>%pathname%</string>
-                <key>destination_path</key>
+                <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/GoogleChrome-%version%.pkg</string>
-                <key>overwrite</key>
-                <true/>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The `Copier` processor being used does not provide a `pkg_path` variable used by JSSImporter, so downstream .jss recipes which use this recipe as a parent are not uploading installer packages to Jamf Pro servers. 

I'm updating the recipe to use the `PkgCopier` processor instead, which does provide the needed `pkg_path` variable.