### PR TITLE
Updated download URL

### DIFF
--- a/Spotify/Spotify.download.recipe
+++ b/Spotify/Spotify.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Spotify</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://download.scdn.co/Spotify.dmg</string>
+        <string>https://download.spotify.com/Spotify.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>


### PR DESCRIPTION
The old download URL was not pulling the most recent version from Spotify.