### PR TITLE
Update Adobe signing cert name

### DIFF
--- a/AdobeFlashPlayer/AdobeFlashPlayer.download.recipe
+++ b/AdobeFlashPlayer/AdobeFlashPlayer.download.recipe
@@ -41,7 +41,7 @@
                 <string>%pathname%/Install Adobe Flash Player.app/Contents/Resources/Adobe Flash Player.pkg</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Adobe Systems, Inc. (JQ525L2MZD)</string>
+                    <string>Developer ID Installer: Adobe Inc. (JQ525L2MZD)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
In today's autopkg run I found an error caused by a name change in the Adobe signing cert. This PR changes to the new name.