### PR TITLE
Add a recipe to build a chocolatey/nuget package for Firefox

### DIFF
--- a/Mozilla/Firefox.nupkg.recipe
+++ b/Mozilla/Firefox.nupkg.recipe
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Description</key>
+        <string>This recipe creates a Chocolatey package from the downloaded Windows MSI
+    installer obtained from the com.github.autopkg.download.FirefoxWindows recipe.
+        </string>
+        <key>Identifier</key>
+        <string>com.github.autopkg.nupkg.Firefox</string>
+        <key>Input</key>
+        <dict>
+            <!-- All relevant inputs inherited from parent recipe. -->
+        </dict>
+        <key>MinimumVersion</key>
+        <string>1.1</string>
+        <key>SupportedPlatforms</key>
+        <array>
+            <string>Windows</string>
+        </array>
+        <key>ParentRecipe</key>
+        <string>com.github.autopkg.download.FirefoxWindows</string>
+        <key>Process</key>
+        <array>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>id</key>
+                    <string>firefox-%moz_locale%</string>
+                    <key>version</key>
+                    <string>%moz_version%</string>
+                    <key>title</key>
+                    <string>Firefox</string>
+                    <key>authors</key>
+                    <string>Mozilla</string>
+                    <key>description</key>
+                    <string>Firefox Web Browser</string>
+                    <key>installer_type</key>
+                    <string>msi</string>
+                </dict>
+                <key>Processor</key>
+                <string>ChocolateyPackager</string>
+            </dict>
+        </array>
+    </dict>
+</plist>

--- a/Mozilla/FirefoxWindows.download.recipe
+++ b/Mozilla/FirefoxWindows.download.recipe
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Description</key>
+		<string>This recipe downloads the latest 64-bit or 32-bit Windows MSI installer.
+		</string>
+		<key>Identifier</key>
+		<string>com.github.autopkg.download.FirefoxWindows</string>
+		<key>Input</key>
+		<dict>
+			<key>LOCALE</key>
+			<string>en-US</string>
+			<key>NAME</key>
+			<string>Firefox</string>
+			<key>PLATFORM</key>
+			<string>win64</string>			<!-- default 64 bit, 'win' can be used for 32 bit. -->
+			<key>RELEASE</key>
+			<string>msi-latest</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>1.1</string>
+		<key>SupportedPlatforms</key>
+		<array>
+			<string>Windows</string>
+		</array>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>product_name</key>
+					<string>firefox</string>
+					<key>release</key>
+					<string>%RELEASE%</string>
+					<key>locale</key>
+					<string>%LOCALE%</string>
+					<key>platform</key>
+					<string>%PLATFORM%</string>
+				</dict>
+				<key>Processor</key>
+				<string>MozillaURLProvider</string>
+			</dict>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>prefetch_filename</key>
+					<string>True</string>
+				</dict>
+				<key>Processor</key>
+				<string>URLDownloader</string>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>EndOfCheckPhase</string>
+			</dict>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>additional_arguments</key>
+					<array>
+						<!--
+						Validate the download has a signature from this explicitly:
+						Issued to: Mozilla Corporation
+						Issued by: DigiCert SHA2 Assured ID Code Signing CA
+						Expires:   Wed May 12 05:00:00 2021
+						SHA1 hash: 91CABEA509662626E34326687348CAF2DD3B4BBA
+						-->
+						<string>/sha1</string>
+						<string>91CABEA509662626E34326687348CAF2DD3B4BBA</string>
+					</array>
+					<key>input_path</key>
+					<string>%pathname%</string>
+				</dict>
+				<key>Processor</key>
+				<string>SignToolVerifier</string>
+			</dict>
+		</array>
+	</dict>
+</plist>

--- a/Mozilla/MozillaURLProvider.py
+++ b/Mozilla/MozillaURLProvider.py
@@ -17,26 +17,60 @@
 
 from __future__ import absolute_import
 
+import json
+import re
+import ssl
+from typing import List, Tuple
+from urllib.request import urlopen
+
 from autopkglib import Processor
 
-__all__ = ["MozillaURLProvider"]
+__all__: List[str] = ["MozillaURLProvider"]
 
 
-MOZ_BASE_URL = "https://download.mozilla.org/?product=%s-%s&os=osx&lang=%s"
+MOZ_BASE_URL: str = (
+    "https://download.mozilla.org/"
+    "?product={product_release}-ssl&os={platform}&lang={locale}"
+)
 
-# As of 16 Nov 2015 here are the supported products:
-# firefox-latest
-# firefox-esr-latest
-# firefox-beta-latest
-# thunderbird-latest
-# thunderbird-beta-latest
+MOZ_PRODUCT_VERSIONS_URL: str = (
+    "https://product-details.mozilla.org/1.0/{product}_versions.json"
+)
+
+# As of July/2020 here are the known supported products, releases, and platforms:
+# For linux, linux64, osx, win, and win64:
+#  Product            Release
+#  -------            -------
+#  firefox            latest
+#  firefox            version   (i.e., 79.0)
+#  firefox-beta       latest
+#  firefox-esr        latest
+#  firefox-nightly    latest
+#
+#  thunderbird        latest
+#  thunderbird        version (i.e., 78.0)
+#  thunderbird-beta   latest
+# Additionally for win and win64 there are additional releases for MSI installers:
+#  msi-latest
+#  <version>-msi (i.e., 79.0-msi)
+# Note that the position of 'msi' is different.
+#
+#  Platforms
+#  ---------
+#  linux
+#  linux64
+#  osx
+#  win
+#  win64
 #
 # See also:
-#    http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt
-#    http://ftp.mozilla.org/pub/firefox/releases/latest-esr/README.txt
-#    http://ftp.mozilla.org/pub/firefox/releases/latest-beta/README.txt
-#    http://ftp.mozilla.org/pub/thunderbird/releases/latest/README.txt
-#    http://ftp.mozilla.org/pub/thunderbird/releases/latest-beta/README.txt
+#    https://releases.mozilla.org/pub/firefox/releases/latest/README.txt
+#    https://releases.mozilla.org/pub/firefox/releases/latest-esr/README.txt
+#    https://releases.mozilla.org/pub/firefox/releases/latest-beta/README.txt
+#    https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt
+#    https://releases.mozilla.org/pub/thunderbird/releases/latest-beta/README.txt
+#    https://product-details.mozilla.org/1.0/firefox_versions.json
+#    https://product-details.mozilla.org/1.0/thunderbird_versions.json
 
 
 class MozillaURLProvider(Processor):
@@ -46,56 +80,146 @@ class MozillaURLProvider(Processor):
     input_variables = {
         "product_name": {
             "required": True,
-            "description": "Product to fetch URL for. One of 'firefox', 'thunderbird'.",
+            "description": (
+                "Product to fetch URL for. One of: "
+                "'firefox', 'firefox-esr', 'firefox-beta', 'firefox-nightly', "
+                "'thunderbird', 'thunderbird-beta'."
+            ),
         },
         "release": {
             "required": False,
             "default": "latest",
-            "description": (
-                "Which release to download. Examples: 'latest', "
-                "'esr-latest', 'beta-latest'. Defaults to 'latest'"
-            ),
+            "description": ("Which release to download. Examples: 'latest', 79.0"),
         },
         "locale": {
             "required": False,
             "default": "en-US",
-            "description": "Which localization to download, default is 'en-US'.",
+            "description": ("Which localization to download, default is 'en-US'."),
+        },
+        "platform": {
+            "required": False,
+            "default": "osx",
+            "description": "Which platform/OS to download: 'osx' (default), 'linux', "
+            "'linux64', 'win', 'win64'.",
         },
         "base_url": {
             "required": False,
-            "description": "Default is '%s." % MOZ_BASE_URL,
+            "description": (
+                f"(Advanced) URL for downloads.  Default is '{MOZ_BASE_URL}'."
+            ),
+            "default": MOZ_BASE_URL,
+        },
+        "versions_base_url": {
+            "required": False,
+            "description": (
+                "(Advanced) URL for product release version information. "
+                f" Default is '{MOZ_PRODUCT_VERSIONS_URL}'."
+            ),
+            "default": MOZ_PRODUCT_VERSIONS_URL,
         },
     }
     output_variables = {
-        "url": {"description": "URL to the latest Mozilla product release."}
+        "url": {"description": "URL to the latest Mozilla product release."},
+        "moz_version": {
+            "description": (
+                "Resolved version number for a release normalized to a 3 or 4 digit "
+                "semantic version. For example:  'latest-beta' -> 79.0b9 -> 79.0.0.9"
+            )
+        },
+        "moz_original_version": {
+            "description": (
+                "Pre-normalized version number from the product versions information."
+            )
+        },
     }
 
-    def get_mozilla_dmg_url(self, base_url, product_name, release, locale):
-        """Assemble download URL for Mozilla product"""
+    def fixup_locale(self, locale: str) -> str:
         # Allow locale as both en-US and en_US.
-        locale = locale.replace("_", "-")
+        return locale.replace("_", "-")
 
-        # fix releases into new format
-        if release == "latest-esr":
-            release = "esr-latest"
-        if release == "latest-beta":
-            release = "beta-latest"
+    def fixup_product_release(self, product: str, release: str) -> str:
+        # Fix product and release into correct format for legacy inputs.
+        if release in ("latest-esr", "esr-latest"):
+            product += "-esr"
+            release = "latest"
+        elif release in ("latest-beta", "beta-latest"):
+            product += "-beta"
+            release = "latest"
 
-        # Construct download URL.
-        return base_url % (product_name, release, locale)
+        return f"{product}-{release}"
+
+    def normalize_version(self, orig_version: str) -> str:
+        """Versions are normalized like these examples:
+        * 78.0.2 into 78.0.2,
+        * 79.0b9 into 79.0.0.9,
+        * 68.10.0esr into 68.10.0,
+        * 77.0-msi into 77.0 (a special case for Windows MSI)."""
+        norm_version = re.sub(r"[ab]", ".0.", orig_version)
+        norm_version = norm_version.replace("esr", "")
+        norm_version = norm_version.replace("-msi", "")
+        return norm_version
+
+    def resolve_product_release_version(
+        self, base_url: str, product: str, release: str
+    ) -> Tuple[str, str]:
+        """Resolves a symbolic release like 'latest' to a normalized version number.
+        Returns a tuple of (normalized version, original version from web api)"""
+        context = ssl.SSLContext()
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.check_hostname = True
+        context.load_default_certs()
+
+        if "firefox" in product:
+            simple_product = "firefox"
+        elif "thunderbird" in product:
+            simple_product = "thunderbird"
+        else:
+            raise ValueError(f"Product '{product}' is not a supported product.")
+
+        product_release = self.fixup_product_release(product, release)
+        release_key = ""
+        # Some of these keys are not supported for Thunderbird as of July/2020.
+        if "esr" in product_release:
+            release_key = f"{simple_product.upper()}_ESR"
+        elif "beta" in product_release:
+            release_key = f"LATEST_{simple_product.upper()}_DEVEL_VERSION"
+        elif "nightly" in product_release:
+            release_key = f"{simple_product.upper()}_NIGHTLY"
+        elif "latest" in product_release:
+            release_key = f"LATEST_{simple_product.upper()}_VERSION"
+        else:
+            # In this case, it must be an unknown symbolic release or a version number.
+            # Pass it through normalization, which *should* leave unknown symbolic
+            # releases more or less untouched.
+            return (self.normalize_version(release), release)
+
+        with urlopen(base_url.format(product=simple_product), context=context) as res:
+            release_data = json.loads(res.read())
+            orig_version = release_data[release_key]
+            return (self.normalize_version(orig_version), orig_version)
 
     def main(self):
         """Provide a Mozilla download URL"""
         # Determine product_name, release, locale, and base_url.
         product_name = self.env["product_name"]
         release = self.env.get("release", "latest")
-        locale = self.env.get("locale", "en-US")
+        locale = self.fixup_locale(self.env.get("locale", "en-US"))
+        platform = self.env.get("platform", "osx")
         base_url = self.env.get("base_url", MOZ_BASE_URL)
 
-        self.env["url"] = self.get_mozilla_dmg_url(
-            base_url, product_name, release, locale
+        self.env["url"] = base_url.format(
+            product_release=self.fixup_product_release(product_name, release),
+            platform=platform,
+            locale=locale,
         )
-        self.output("Found URL %s" % self.env["url"])
+        (
+            self.env["moz_version"],
+            self.env["moz_original_version"],
+        ) = self.resolve_product_release_version(
+            self.env["versions_base_url"], product_name, release
+        )
+        self.env["moz_locale"] = locale
+        self.output(f"Found URL {self.env['url']}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This depends on autopkg/autopkg#653 and autopkg/autopkg#656.

The PR contains substantial changes to `MozillaURLProvider` to support a broader range of Firefox and Thunderbird releases, as well as ensuring that the downloads are delivered over TLS (the addition of the `-ssl` to the `product` URL parameter). The processor also now looks up version information when run to make that more readily available to other packaging recipes. However, I did not make changes to roll it out beyond this new recipe.

I've tested fresh installs and upgrades of this package on Windows. The output is trivial and did not appear to warrant capturing. 
I have not yet done testing on macOS to ensure that these changes have not broken other recipes.