### PR TITLE
Fix MozillaURLProvider SSL/TLS errors per #350

### DIFF
--- a/Mozilla/Firefox.download.recipe
+++ b/Mozilla/Firefox.download.recipe
@@ -25,7 +25,7 @@ See the following URLs for more info:
         <false />
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.1</string>
+    <string>1.4</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
Since updating the parent trust info for MozillaURLProvider.py earlier I have been seeing these errors:
```
Processor: MozillaURLProvider: Error: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)
```

I asked ([MacAdmins Slack #autopkg comment](https://macadmins.slack.com/archives/C056155B4/p1596116717092900)) if others had seen similar and at least one other person was.

Taking a quick look at the code it _appeared_ that the fix would be to change the handling of the HTTP request from the former urllib-based to the new URLGetter class. This merge request is my attempt to do that. It _seems_ to work fine, but others with more experience with the code base should take a look first.