### PR TITLE
Update MSOfficeMacURLandUpdateInfoProvider.py

### DIFF
--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -312,20 +312,6 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
         # now extract useful info from the rest of the metadata that could
         # be used in a pkginfo
         pkginfo = {}
-        # Get a copy of the description in our locale_id
-        all_localizations = item.get("Localized")
-        lcid = self.env["locale_id"]
-        if lcid not in all_localizations:
-            raise ProcessorError(
-                "Locale ID %s not found in manifest metadata. Available IDs: "
-                "%s. See %s for more details."
-                % (lcid, ", ".join(all_localizations), LOCALE_ID_INFO_URL)
-            )
-        manifest_description = all_localizations[lcid]["Short Description"]
-        # Store the description in a separate output variable and in our pkginfo
-        # directly.
-        pkginfo["description"] = "<html>%s</html>" % manifest_description
-        self.env["description"] = manifest_description
 
         # Minimum OS version key should exist!
         pkginfo["minimum_os_version"] = (


### PR DESCRIPTION
Appears that the description is no longer published in the XML for Office 2019 (& therefore 365), this has made the processor fail:

```
autopkg run -vvv /Users/ben/Git/other-recipes/recipes/MSOfficeUpdates/MSExcel2019.download.recipe
Processing /Users/ben/Git/other-recipes/recipes/MSOfficeUpdates/MSExcel2019.download.recipe...
WARNING: /Users/ben/Git/other-recipes/recipes/MSOfficeUpdates/MSExcel2019.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.1',
 'CHANNEL': 'Production',
 'GIT_PATH': '/Applications/Xcode.app/Contents/Developer/usr/bin/git',
 'LOCALE_ID': '1033',
 'MUNKI_REPO': '/Users/Shared/munki_repo',
 'NAME': 'MSExcel2019',
 'PARENT_RECIPES': ['/Users/ben/Git/other-recipes/recipes/MSOfficeUpdates/MSOfficeMacProduct.download.recipe'],
 'PRODUCT': 'Excel2019',
 'RECIPE_CACHE_DIR': '/Users/ben/Library/AutoPkg/Cache/com.github.autopkg.download.MSExcel2019',
 'RECIPE_DIR': '/Users/ben/Git/other-recipes/recipes/MSOfficeUpdates',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/ben/Git/other-recipes/recipes/MSOfficeUpdates/MSExcel2019.download.recipe',
 'RECIPE_REPOS': {'/Users/ben/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes': {'URL': 'https://github.com/autopkg/homebysix-recipes.git'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/ben/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes',
                        '/Users/ben/Git/other-recipes/recipes/MSOfficeUpdates'],
 'VERSION': 'latest',
 'verbose': 3}
MSOfficeMacURLandUpdateInfoProvider
{'Input': {'channel': 'Production',
           'locale_id': '1033',
           'product': 'Excel2019',
           'version': 'latest'}}
MSOfficeMacURLandUpdateInfoProvider: No value supplied for munki_required_update_name, setting default value of:
MSOfficeMacURLandUpdateInfoProvider: Requesting xml: https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409XCEL2019.xml
MSOfficeMacURLandUpdateInfoProvider: Found URL https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Excel_16.40.20081000_Updater.pkg
MSOfficeMacURLandUpdateInfoProvider: Got update: 'Excel Update 16.40.0 (20081000)'
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 676, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 483, in process
    self.main()
  File "/Users/ben/Git/other-recipes/recipes/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py", line 395, in main
    self.get_installer_info()
  File "/Users/ben/Git/other-recipes/recipes/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py", line 323, in get_installer_info
    if lcid not in all_localizations:
TypeError: argument of type 'NoneType' is not iterable
  File "/Library/AutoPkg/autopkglib/__init__.py", line 676, in process
    self.env = processor.process()
argument of type 'NoneType' is not iterable
Failed.
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.autopkg.download.MSExcel2019/receipts/MSExcel2019.download-receipt-20200812-092950.plist

The following recipes failed:
    /Users/ben/Git/other-recipes/recipes/MSOfficeUpdates/MSExcel2019.download.recipe
        Error in com.github.autopkg.download.MSExcel2019: Processor: MSOfficeMacURLandUpdateInfoProvider: Error: argument of type 'NoneType' is not iterable

Nothing downloaded, packaged or imported.
```

But everything works with the section grabbing the description removed.

If this PR is accepted, descriptions will not be grabbed for any office app (incuding 2016) & will need to be manually set.

For example, for Word:
```
Word helps you put your best words forward – anytime, anywhere and with anyone. A new, modern take on the desktop application built for the creation of polished documents.` from: https://www.microsoft.com/en-gb/microsoft-365/p/word/cfq7ttc0k7c7?=&ef_id=EAIaIQobChMIgsa25KSV6wIVDOvtCh3xfAyWEAAYASAAEgL-a_D_BwE%3aG%3as&OCID=AID2100139_SEM_PeRJd0BE&MarinID=sPeRJd0BE%7c430713982733%7cmicrosoft+word+for+mac%7ce%7cc%7c%7c68423118144%7ckwd-12607780&lnkd=Google_O365SMB_App&gclid=EAIaIQobChMIgsa25KSV6wIVDOvtCh3xfAyWEAAYASAAEgL-a_D_BwE&activetab=pivot%3aoverviewtab
```