### PR TITLE
Fix munkitools_app_usage imported as munkitools_app

### DIFF
--- a/munkitools/munkitools5.munki.recipe
+++ b/munkitools/munkitools5.munki.recipe
@@ -186,7 +186,7 @@ MUNKI_ICON should be overridden with your icon name.
             <key>Arguments</key>
             <dict>
                 <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_app*.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_app[.-]*pkg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Small change to the munkitools_app FileFinder glob to prevent it from matching munkitools_app_usage