### PR TITLE
Update GoogleEarth.download.recipe

### DIFF
--- a/GoogleEarth/GoogleEarth.download.recipe
+++ b/GoogleEarth/GoogleEarth.download.recipe
@@ -41,7 +41,7 @@
                 <string>%pathname%/Install Google Earth*.pkg</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Google LLC (EQHXZ8M8AV)</string>
+                    <string>Developer ID Installer: Google, Inc. (EQHXZ8M8AV)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
The package signature changed slightly. Updated to the new Google, Inc. developer ID cert.