### PR TITLE
Add CodeSignatureVerifier to OmniDiskSweeper.download

### DIFF
--- a/OmniGroup/OmniDiskSweeper.download.recipe
+++ b/OmniGroup/OmniDiskSweeper.download.recipe
@@ -15,5 +15,21 @@
 	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.omnigroupproduct</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/OmniDiskSweeper.app</string>
+				<key>requirement</key>
+				<string>identifier "com.omnigroup.OmniDiskSweeper" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "34YW5XSRB7"</string>
+				<key>strict_verification</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Verbose recipe output after change:

```
autopkg run ~/Documents/git/recipes/OmniGroup/OmniDiskSweeper.download.recipe -vv
Processing /Users/admin/Documents/git/recipes/OmniGroup/OmniDiskSweeper.download.recipe...
WARNING: /Users/admin/Documents/git/recipes/OmniGroup/OmniDiskSweeper.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'alternate_xmlns_url': 'https://www.omnigroup.com/namespace/omniappcast/v1',
           'appcast_url': 'https://update.omnigroup.com/appcast/com.omnigroup.OmniDiskSweeper'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.12.1
SparkleUpdateInfoProvider: Found URL https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-1.12.1.dmg
{'Output': {'url': 'https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-1.12.1.dmg',
            'version': '1.12.1'}}
URLDownloader
{'Input': {'url': 'https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-1.12.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 25 Feb 2020 00:31:07 GMT
URLDownloader: Storing new ETag header: "64f0d-666bd3-59f5b9a8808c0"
URLDownloader: Downloaded /Users/admin/Library/AutoPkg/Cache/com.github.autopkg.download.OmniDiskSweeper/downloads/OmniDiskSweeper-1.12.1.dmg
{'Output': {'download_changed': True,
            'etag': '"64f0d-666bd3-59f5b9a8808c0"',
            'last_modified': 'Tue, 25 Feb 2020 00:31:07 GMT',
            'pathname': '/Users/admin/Library/AutoPkg/Cache/com.github.autopkg.download.OmniDiskSweeper/downloads/OmniDiskSweeper-1.12.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/admin/Library/AutoPkg/Cache/com.github.autopkg.download.OmniDiskSweeper/downloads/OmniDiskSweeper-1.12.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/admin/Library/AutoPkg/Cache/com.github.autopkg.download.OmniDiskSweeper/downloads/OmniDiskSweeper-1.12.1.dmg/OmniDiskSweeper.app',
           'requirement': 'identifier "com.omnigroup.OmniDiskSweeper" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"34YW5XSRB7"',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.autopkg.download.OmniDiskSweeper/downloads/OmniDiskSweeper-1.12.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.YvtgjF/OmniDiskSweeper.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.YvtgjF/OmniDiskSweeper.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.YvtgjF/OmniDiskSweeper.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.autopkg.download.OmniDiskSweeper/receipts/OmniDiskSweeper.download-receipt-20201006-150656.plist

The following new items were downloaded:
    Download Path                                                                                                      
    -------------                                                                                                      
    /Users/admin/Library/AutoPkg/Cache/com.github.autopkg.download.OmniDiskSweeper/downloads/OmniDiskSweeper-1.12.1.dmg
```