### PR TITLE
Added an optional U symbol for the new universal binary.

### DIFF
--- a/Praat/Praat.download.recipe
+++ b/Praat/Praat.download.recipe
@@ -27,7 +27,7 @@ causing the CodeSignatureVerifier step to fail and print a warning.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>a href="?(praat\d+_mac%ARCH_EDITION%.dmg)"?</string>
+				<string>a href="?(praat\d+_macU?%ARCH_EDITION%.dmg)"?</string>
 				<key>result_output_var_name</key>
 				<string>dl_filename</string>
 				<key>url</key>


### PR DESCRIPTION
This PR adds an optional U character to the URLTextSearcher regex, as Praat is now provided as a Universal app (U64). This fixes an issue where the recipe wouldn't download anything, as it was unable to find a regex match on the page.