### PR TITLE
ARCH_EDITION removed a href="?(praat\d+_mac.dmg)"?

### DIFF
--- a/Praat/Praat.download.recipe
+++ b/Praat/Praat.download.recipe
@@ -27,7 +27,7 @@ causing the CodeSignatureVerifier step to fail and print a warning.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>a href="?(praat\d+_mac%ARCH_EDITION%.dmg)"?</string>
+				<string>a href="?(praat\d+_mac.dmg)"?</string>
 				<key>result_output_var_name</key>
 				<string>dl_filename</string>
 				<key>url</key>


### PR DESCRIPTION
Update the URLTextSearcher re_pattern .... looks like the link no longer includes %ARCH_EDITION%.  i.e. the link is currently https://www.fon.hum.uva.nl/praat/praat6133_mac.dmg so ... `a href="?(praat\d+_mac.dmg)"?` ... should work.