### PR TITLE
Fix Praat download

### DIFF
--- a/Praat/Praat.download.recipe
+++ b/Praat/Praat.download.recipe
@@ -3,19 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Praat.
-
-There are two editions that can be downloaded: 32-bit or 64-bit, which
-can be overridden by setting ARCH_EDITION to either '32' or '64'.
-
-Note that the 32-bit edition may not have a valid code signature,
-causing the CodeSignatureVerifier step to fail and print a warning.</string>
+	<string>Downloads the latest version of Praat.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.download.Praat</string>
 	<key>Input</key>
 	<dict>
-		<key>ARCH_EDITION</key>
-		<string>64</string>
 		<key>NAME</key>
 		<string>Praat</string>
 	</dict>
@@ -27,7 +19,7 @@ causing the CodeSignatureVerifier step to fail and print a warning.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>a href="?(praat\d+_mac%ARCH_EDITION%.dmg)"?</string>
+				<string>a href="?(praat\d+_mac.dmg)"?</string>
 				<key>result_output_var_name</key>
 				<string>dl_filename</string>
 				<key>url</key>

--- a/Praat/Praat.munki.recipe
+++ b/Praat/Praat.munki.recipe
@@ -3,16 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Praat and imports into Munki.
-
-There are two editions that can be downloaded: 32-bit or 64-bit, which
-can be overridden by setting ARCH_EDITION to either '32' or '64'.</string>
+	<string>Downloads the latest version of Praat and imports into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.munki.Praat</string>
 	<key>Input</key>
 	<dict>
-		<key>ARCH_EDITION</key>
-		<string>64</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps</string>
 		<key>NAME</key>


### PR DESCRIPTION
Looks like they [ditched](https://www.fon.hum.uva.nl/praat/download_mac.html) the arch specific packages.