### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Mozilla/FirefoxSignedPkg.download.recipe
+++ b/Mozilla/FirefoxSignedPkg.download.recipe
@@ -52,7 +52,7 @@ See the following URL for possible LOCALE values:
 				<key>filename</key>
 				<string>%NAME%-%version%.pkg</string>
 				<key>url</key>
-				<string>http://releases.mozilla.org/pub/firefox/releases/%version%/mac/%LOCALE%/Firefox%20%version%.pkg</string>
+				<string>https://releases.mozilla.org/pub/firefox/releases/%version%/mac/%LOCALE%/Firefox%20%version%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/TextMate/TextMate.download.recipe
+++ b/TextMate/TextMate.download.recipe
@@ -22,7 +22,7 @@ is hardcoded because it's not likely to ever get another update.</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://archive.textmate.org/TextMate_1.5.11_r1635.zip</string>
+                <string>https://archive.textmate.org/TextMate_1.5.11_r1635.zip</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Verbose run for the 2 modified recipes:

```
% git diff master --name-only > /tmp/recipe_list.txt; autopkg run -vvcql /tmp/recipe_list.txt
Processing Mozilla/FirefoxSignedPkg.download.recipe...
WARNING: Mozilla/FirefoxSignedPkg.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '"LATEST_FIREFOX_VERSION": "([\\d\\.abesr]+)"',
           'result_output_var_name': 'version',
           'url': 'https://product-details.mozilla.org/1.0/firefox_versions.json'}}
URLTextSearcher: Found matching text (version): 84.0.2
{'Output': {'version': '84.0.2'}}
URLDownloader
{'Input': {'filename': 'Firefox-84.0.2.pkg',
           'url': 'https://releases.mozilla.org/pub/firefox/releases/84.0.2/mac/en-US/Firefox%2084.0.2.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.FirefoxSignedPkg/downloads/Firefox-84.0.2.pkg
{'Output': {'pathname': '/Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.FirefoxSignedPkg/downloads/Firefox-84.0.2.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.FirefoxSignedPkg/receipts/FirefoxSignedPkg.download-receipt-20210107-222148.plist
Processing TextMate/TextMate.download.recipe...
WARNING: TextMate/TextMate.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://archive.textmate.org/TextMate_1.5.11_r1635.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.TextMate/downloads/TextMate_1.5.11_r1635.zip
{'Output': {'pathname': '/Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.TextMate/downloads/TextMate_1.5.11_r1635.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.TextMate/receipts/TextMate.download-receipt-20210107-222149.plist

Nothing downloaded, packaged or imported.
```