### PR TITLE
Use Universal2 Chrome download URL by default

### DIFF
--- a/GoogleChrome/GoogleChrome.download.recipe
+++ b/GoogleChrome/GoogleChrome.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>GoogleChrome</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg</string>
+        <string>https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
This change makes the Universal2 version of Chrome, which is compatible with both Intel and Apple Silicon Macs, the default option for newly created recipe overrides.

As before, AutoPkg users can modify the `DOWNLOAD_URL` in their existing overrides to download whichever version of Chrome they prefer.

Closes #368.

Verbose run:

```
% autopkg run -vv GoogleChrome/GoogleChrome.download.recipe 
Processing GoogleChrome/GoogleChrome.download.recipe...
WARNING: GoogleChrome/GoogleChrome.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'GoogleChrome.dmg',
           'url': 'https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg
{'Output': {'pathname': '/Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg/Google '
                         'Chrome.app',
           'requirement': '(identifier "com.google.Chrome" or identifier '
                          '"com.google.Chrome.beta" or identifier '
                          '"com.google.Chrome.dev" or identifier '
                          '"com.google.Chrome.canary") and (certificate leaf = '
                          'H"85cee8254216185620ddc8851c7a9fc4dfe120ef" or '
                          'certificate leaf = '
                          'H"c9a99324ca3fcb23dbcc36bd5fd4f9753305130a")',
           'strict_verification': False}}
CodeSignatureVerifier: Mounted disk image /Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification disabled...
CodeSignatureVerifier: /private/tmp/dmg.7nRhXH/Google Chrome.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.7nRhXH/Google Chrome.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.7nRhXH/Google Chrome.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/elliotj/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/receipts/GoogleChrome.download-receipt-20210108-094325.plist

Nothing downloaded, packaged or imported.
```