### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/AdobeAIR/AdobeAIR.pkg.recipe
+++ b/AdobeAIR/AdobeAIR.pkg.recipe
@@ -235,10 +235,10 @@ Based on jamesz's work here: https://github.com/jamesez/automunki/tree/master/ad
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/AutoPkg/AutoPkg1GitMaster.pkg.recipe
+++ b/AutoPkg/AutoPkg1GitMaster.pkg.recipe
@@ -236,10 +236,10 @@ This is not used to obtain the latest released version.
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%</string>
                         <key>id</key>

--- a/AutoPkg/AutoPkgGitMaster.pkg.recipe
+++ b/AutoPkg/AutoPkgGitMaster.pkg.recipe
@@ -287,12 +287,12 @@ This is not used to obtain the latest released version.
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>force_pkg_build</key>
                     <string>True</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%</string>
                         <key>id</key>

--- a/AutoPkg/AutoPkgGitMasterNoPython.pkg.recipe
+++ b/AutoPkg/AutoPkgGitMasterNoPython.pkg.recipe
@@ -236,10 +236,10 @@ This is not used to obtain the latest released version.
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%</string>
                         <key>id</key>

--- a/Barebones/BBEdit.pkg.recipe
+++ b/Barebones/BBEdit.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Dropbox/Dropbox.pkg.recipe
+++ b/Dropbox/Dropbox.pkg.recipe
@@ -61,10 +61,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Evernote/Evernote.pkg.recipe
+++ b/Evernote/Evernote.pkg.recipe
@@ -61,10 +61,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Mozilla/Firefox.pkg.recipe
+++ b/Mozilla/Firefox.pkg.recipe
@@ -63,10 +63,10 @@ See the following URLs for more info:
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Panic/Coda2.pkg.recipe
+++ b/Panic/Coda2.pkg.recipe
@@ -67,10 +67,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Panic/Transmit.pkg.recipe
+++ b/Panic/Transmit.pkg.recipe
@@ -67,10 +67,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Panic/Transmit5.pkg.recipe
+++ b/Panic/Transmit5.pkg.recipe
@@ -67,10 +67,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/VLC/VLC.pkg.recipe
+++ b/VLC/VLC.pkg.recipe
@@ -69,10 +69,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).