### PR TITLE
Remove DISABLE_CODE_SIGNATURE_VERIFICATION input variable for Mozilla recipes

### DIFF
--- a/Mozilla/Firefox.download.recipe
+++ b/Mozilla/Firefox.download.recipe
@@ -21,8 +21,6 @@ See the following URLs for more info:
         <string>en-US</string>
         <key>NAME</key>
         <string>Firefox</string>
-        <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-        <false />
     </dict>
     <key>MinimumVersion</key>
     <string>2.0</string>

--- a/Mozilla/Thunderbird.download.recipe
+++ b/Mozilla/Thunderbird.download.recipe
@@ -20,8 +20,6 @@ See the following URLs for more info:
         <string>en_US</string>
         <key>NAME</key>
         <string>Thunderbird</string>
-        <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-        <false/>
     </dict>
     <key>MinimumVersion</key>
     <string>2.0</string>


### PR DESCRIPTION
Code signature verification is enabled by default for recipes that use CodeSignatureVerifier, so there's no reason to set `DISABLE_CODE_SIGNATURE_VERIFICATION` to false here.