### PR TITLE
Fix spelling of "downloaded" in description of Mozilla recipes

### DIFF
--- a/Mozilla/Firefox.download.recipe
+++ b/Mozilla/Firefox.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Download recipe for Firefox. Finds and downloads a Firefox release disk image.
 Some useful values for RELEASE are: 'latest', 'esr-latest', 'beta-latest'.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URLs for more info:
     http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt

--- a/Mozilla/Firefox.install.recipe
+++ b/Mozilla/Firefox.install.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads Firefox disk image, builds a package and installs it.
 Some useful values for RELEASE are: 'latest', 'esr-latest', 'beta-latest'.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URLs for more info:
     http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt

--- a/Mozilla/Firefox.munki.recipe
+++ b/Mozilla/Firefox.munki.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads Firefox disk image and imports into Munki.
 Some useful values for RELEASE are: 'latest', 'esr-latest', 'beta-latest'.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URLs for more info:
     http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt

--- a/Mozilla/Firefox.pkg.recipe
+++ b/Mozilla/Firefox.pkg.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads Firefox disk image and builds a package.
 Some useful values for RELEASE are: 'latest', 'esr-latest', 'beta-latest'.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URLs for more info:
     http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt

--- a/Mozilla/FirefoxSignedPkg.download.recipe
+++ b/Mozilla/FirefoxSignedPkg.download.recipe
@@ -13,7 +13,7 @@ Other values to try can be found by examining the JSON file at:
     https://product-details.mozilla.org/1.0/firefox_versions.json
 (Not all will work.)
 
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URL for possible LOCALE values:
     http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt

--- a/Mozilla/FirefoxSignedPkg.install.recipe
+++ b/Mozilla/FirefoxSignedPkg.install.recipe
@@ -6,7 +6,7 @@
 	<string>This recipe downloads the signed installer package that Mozilla made available starting in Firefox 69.0, and installs it locally onto the computer running AutoPkg.
 
 The RELEASE key used in the standard Firefox recipes are not yet supported.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URL for possible LOCALE values:
     http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt

--- a/Mozilla/FirefoxSignedPkg.munki.recipe
+++ b/Mozilla/FirefoxSignedPkg.munki.recipe
@@ -6,7 +6,7 @@
 	<string>This recipe downloads the signed installer package that Mozilla made available starting in Firefox 69.0, and imports the pkg file into a Munki repo.
 
 The RELEASE key used in the standard Firefox recipes are not yet supported.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URL for possible LOCALE values:
     http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt

--- a/Mozilla/FirefoxSignedPkg.pkg.recipe
+++ b/Mozilla/FirefoxSignedPkg.pkg.recipe
@@ -6,7 +6,7 @@
 	<string>This recipe downloads the signed installer package that Mozilla made available starting in Firefox 69.0. Because the downloaded file is already a package, this pkg recipe does not add any further actions.
 
 The RELEASE key used in the standard Firefox recipes are not yet supported.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URL for possible LOCALE values:
     http://ftp.mozilla.org/pub/firefox/releases/latest/README.txt

--- a/Mozilla/Thunderbird.download.recipe
+++ b/Mozilla/Thunderbird.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads Thunderbird disk image.
 Some useful values for RELEASE are: 'latest', 'beta-latest'.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URLs for more info:
     http://ftp.mozilla.org/pub/thunderbird/releases/latest/README.txt

--- a/Mozilla/Thunderbird.munki.recipe
+++ b/Mozilla/Thunderbird.munki.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads Thunderbird disk image and imports into Munki.
 Some useful values for RELEASE are: 'latest', 'beta-latest'.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URLs for more info:
     http://ftp.mozilla.org/pub/thunderbird/releases/latest/README.txt

--- a/Mozilla/Thunderbird.pkg.recipe
+++ b/Mozilla/Thunderbird.pkg.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads Thunderbird disk image and builds a package.
 Some useful values for RELEASE are: 'latest', 'beta-latest'.
-LOCALE controls the language localization to be downloded.
+LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URLs for more info:
     http://ftp.mozilla.org/pub/thunderbird/releases/latest/README.txt


### PR DESCRIPTION
Not including recipe run output since the change is only in the description of the affected recipes.