### PR TITLE
VLC.munki.recipe-Allow for supported_architectures override

### DIFF
--- a/VLC/VLC.munki.recipe
+++ b/VLC/VLC.munki.recipe
@@ -4,14 +4,15 @@
 <dict>
     <key>Description</key>
     <string>Downloads latest VLC disk image and imports into Munki.
-
-Please note that the values for supported_architectures in this
-recipe's pkginfo may be only evaluated accurately for early-generation
-Intel Macs as of Munki tools version 0.9.2.</string>
+        This recipe defaults supported_architectures to x86_64. 
+        If you override VLC.download.recipe to %SPARKLE_FEED_URL% to 
+        "https://update.videolan.org/vlc/sparkle/vlc-intel64.xml", update %ARCH% to "arm64".</string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.VLC</string>
     <key>Input</key>
     <dict>
+        <key>ARCH</key>
+        <string>x86_64</string>
         <key>NAME</key>
         <string>VLC</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -32,7 +33,7 @@ Intel Macs as of Munki tools version 0.9.2.</string>
             <true/>
             <key>supported_architectures</key>
             <array>
-                <string>x86_64</string>
+                <string>%ARCH%</string>
             </array>
         </dict>
     </dict>


### PR DESCRIPTION
Allow for supported_architectures to be overridden if pulling the arm64 version of VLC.