### PR TITLE
VLC.download.recipe-convert appcast_url back to variable.

### DIFF
--- a/VLC/VLC.download.recipe
+++ b/VLC/VLC.download.recipe
@@ -5,9 +5,8 @@
     <key>Description</key>
     <string>Downloads latest VLC disk image.
 
-Note that while VLC used to provide multiple Sparkle feeds for different architectures,
-they now support only a single OS X build architecture (Intel 64-bit) starting from
-version 2.1.0. For this reason, the appcast_url variable is now hardcoded in the recipe.
+Default SPARKLE_FEED_URL is the universal Intel build, but path 'vlc-intel64.xml' may be 
+substituted for 'vlc-arm64.xml' to retrieve M1 build.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.VLC</string>
@@ -15,6 +14,8 @@ version 2.1.0. For this reason, the appcast_url variable is now hardcoded in the
     <dict>
         <key>NAME</key>
         <string>VLC</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>http://update.videolan.org/vlc/sparkle/vlc-intel64.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -26,7 +27,7 @@ version 2.1.0. For this reason, the appcast_url variable is now hardcoded in the
             <key>Arguments</key>
             <dict>
                 <key>appcast_url</key>
-                <string>https://update.videolan.org/vlc/sparkle/vlc-intel64.xml</string>
+                <string>%SPARKLE_FEED_URL%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
VLC's sparkle feed is back to two flavors, http://update.videolan.org/vlc/sparkle/vlc-intel64.xml and http://update.videolan.org/vlc/sparkle/vlc-arm64.xml