### PR TITLE
Update VLC description for clarity

### DIFF
--- a/VLC/VLC.download.recipe
+++ b/VLC/VLC.download.recipe
@@ -5,8 +5,8 @@
     <key>Description</key>
     <string>Downloads latest VLC disk image.
 
-Default SPARKLE_FEED_URL is the universal Intel build, but path 'vlc-intel64.xml' may be 
-substituted for 'vlc-arm64.xml' to retrieve M1 build.
+Default SPARKLE_FEED_URL is the Intel build, but path 'vlc-intel64.xml' may be 
+substituted with 'vlc-arm64.xml' to retrieve the M1 build.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.VLC</string>

--- a/VLC/VLC.munki.recipe
+++ b/VLC/VLC.munki.recipe
@@ -5,8 +5,9 @@
     <key>Description</key>
     <string>Downloads latest VLC disk image and imports into Munki.
         This recipe defaults supported_architectures to x86_64. 
-        If you override VLC.download.recipe to %SPARKLE_FEED_URL% to 
-        "https://update.videolan.org/vlc/sparkle/vlc-intel64.xml", update %ARCH% to "arm64".</string>
+        If you override SPARKLE_FEED_URL to 
+        "https://update.videolan.org/vlc/sparkle/vlc-intel64.xml", be sure to
+        adjust ARCH to "arm64".</string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.VLC</string>
     <key>Input</key>


### PR DESCRIPTION
Minor adjustments to the description wording to remove the incorrect term "universal" and clarify override instructions.