### PR TITLE
Adjust Evernote recipes to use latest download source and format

### DIFF
--- a/Evernote/Evernote.download.recipe
+++ b/Evernote/Evernote.download.recipe
@@ -3,19 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Evernote
-
-Alternate Beta URL that can be used for SPARKLE_FEED_URL:
-http://update.evernote.com/prerelease/ENMac/EvernoteMacUpdate.xml
-</string>
+    <string>Downloads the current release version of Evernote.</string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.Evernote</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Evernote</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>https://update.evernote.com/public/ENMacSMD/EvernoteMacUpdate.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -23,16 +17,14 @@ http://update.evernote.com/prerelease/ENMac/EvernoteMacUpdate.xml
     <array>
         <dict>
             <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
+            <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://evernote.com/download/get.php?file=EvernoteMac</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
         </dict>
         <dict>
             <key>Processor</key>
@@ -40,26 +32,22 @@ http://update.evernote.com/prerelease/ENMac/EvernoteMacUpdate.xml
         </dict>
         <dict>
             <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Evernote.app</string>
+                <string>%pathname%/Evernote.app</string>
                 <key>requirement</key>
                 <string>(anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Q79WDW8YH9) and identifier "com.evernote.Evernote"</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>AppDmgVersioner</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%pathname%</string>
             </dict>
         </dict>
     </array>

--- a/Evernote/Evernote.munki.recipe
+++ b/Evernote/Evernote.munki.recipe
@@ -3,19 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Evernote and imports into Munki.
-
-Alternate Beta URL that can be used for SPARKLE_FEED_URL:
-http://update.evernote.com/prerelease/ENMac/EvernoteMacUpdate.xml
-</string>
+    <string>Downloads the current release version of Evernote and imports into Munki.</string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.Evernote</string>
     <key>Input</key>
     <dict>
-        <key>NAME</key>
-        <string>Evernote</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Evernote</string>
+        <key>NAME</key>
+        <string>Evernote</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -35,34 +31,19 @@ http://update.evernote.com/prerelease/ENMac/EvernoteMacUpdate.xml
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-	<string>com.github.autopkg.download.Evernote</string>
+    <string>com.github.autopkg.download.Evernote</string>
     <key>Process</key>
-	<array>
+    <array>
         <dict>
             <key>Processor</key>
-            <string>DmgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
+            <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%dmg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
         </dict>
     </array>
 </dict>

--- a/Evernote/Evernote.pkg.recipe
+++ b/Evernote/Evernote.pkg.recipe
@@ -3,87 +3,23 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-	<string>Downloads the latest version of Evernote and makes a pkg of it
-</string>
+    <string>Downloads the latest version of Evernote and makes a pkg of it.</string>
     <key>Identifier</key>
     <string>com.github.autopkg.pkg.Evernote</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Evernote</string>
-        <key>PKG_ID</key>
-        <string>com.evernote.Evernote</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
-	<string>com.github.autopkg.download.Evernote</string>
+    <string>com.github.autopkg.download.Evernote</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%pkgroot%/Applications/Evernote.app/Contents/Info.plist</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>pkgdir</key>
-                    <string>%RECIPE_CACHE_DIR%</string>
-                    <key>id</key>
-                    <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
+            <string>AppPkgCreator</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
The Evernote Sparkle feed, which the Evernote.download recipe is using, only contains versions up to 7.14. The latest version of Evernote downloadable from evernote.com is 10.15.6.

This PR adjusts the Evernote.download recipe to use the same static URL referenced by the Evernote download page, which provides a disk image.

Adjustments to the munki and pkg recipes have been made corresponding to the file format change from zip to dmg.

The ability to override the Sparkle feed and obtain prerelease versions of Evernote is removed by this PR, but that Sparkle feed appears to have been empty for a while. There is a beta program, but I'm not a member and don't know whether a static URL exists for the beta download.

The `AppDmgVersioner` processor has been included in the download recipe as a convenience for child recipes that may require version information downstream.

I'll post test output shortly for each of the 3 modified recipes.