### PR TITLE
Update AdobeReaderDC.download.recipe

### DIFF
--- a/AdobeReader/AdobeReaderDC.download.recipe
+++ b/AdobeReader/AdobeReaderDC.download.recipe
@@ -56,7 +56,7 @@
                 <string>%pathname%/*.pkg</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Adobe Systems, Inc. (JQ525L2MZD)</string>
+                    <string>Developer ID Installer: Adobe Inc. (JQ525L2MZD)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
Updated CodeSignatureVerifier expected_authority_names

```
pkgutil --check-signature /Volumes/AcroRdrDC_2100720091_MUI/AcroRdrDC_2100720091_MUI.pkg
Package "AcroRdrDC_2100720091_MUI.pkg":
   Status: signed by a developer certificate issued by Apple for distribution
   Signed with a trusted timestamp on: 2021-09-09 05:46:21 +0000
   Certificate Chain:
    1. Developer ID Installer: Adobe Inc. (JQ525L2MZD)
       Expires: 2025-03-20 15:53:03 +0000
       SHA256 Fingerprint:
           EB A4 77 C5 66 4C 70 60 7B CD 99 73 19 24 5D FF 1A 94 85 A9 32 37
           CE 14 9C FD 5C B9 1A 39 CA C5
       ------------------------------------------------------------------------
    2. Developer ID Certification Authority
       Expires: 2027-02-01 22:12:15 +0000
       SHA256 Fingerprint:
           7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
           F2 9C 88 CF B0 B1 BA 63 58 7F
       ------------------------------------------------------------------------
    3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
           68 C5 BE 91 B5 A1 10 01 F0 24
```

Resolves #401