### PR TITLE
Adjust VLC recipes to use Universal download

### DIFF
--- a/VLC/VLC.download.recipe
+++ b/VLC/VLC.download.recipe
@@ -5,8 +5,10 @@
     <key>Description</key>
     <string>Downloads latest VLC disk image.
 
-Default SPARKLE_FEED_URL is the Intel build, but path 'vlc-intel64.xml' may be 
-substituted with 'vlc-arm64.xml' to retrieve the M1 build.
+Allowable ARCHITECTURE values (as of October 2021) include:
+- "universal" for the Universal build (this is the default)
+- "intel64" for the Intel build
+- "arm64" for the Apple Silicon build
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.VLC</string>
@@ -14,8 +16,8 @@ substituted with 'vlc-arm64.xml' to retrieve the M1 build.
     <dict>
         <key>NAME</key>
         <string>VLC</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>https://update.videolan.org/vlc/sparkle/vlc-intel64.xml</string>
+        <key>ARCHITECTURE</key>
+        <string>universal</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -23,11 +25,15 @@ substituted with 'vlc-arm64.xml' to retrieve the M1 build.
     <array>
         <dict>
             <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
+            <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
+                <key>url</key>
+                <string>https://www.videolan.org/vlc/download-macosx.html</string>
+                <key>re_pattern</key>
+                <string>href="\/\/get\.videolan\.org\/vlc\/([\d\.]+)\/macosx\/vlc-[\d\.]+-%ARCHITECTURE%\.dmg"</string>
+                <key>result_output_var_name</key>
+                <string>version</string>
             </dict>
         </dict>
         <dict>
@@ -35,8 +41,10 @@ substituted with 'vlc-arm64.xml' to retrieve the M1 build.
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
+                <key>url</key>
+                <string>https://get.videolan.org/vlc/%version%/macosx/vlc-%version%-%ARCHITECTURE%.dmg</string>
                 <key>filename</key>
-                <string>%NAME%.dmg</string>
+                <string>%NAME%-%version%.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/VLC/VLC.munki.recipe
+++ b/VLC/VLC.munki.recipe
@@ -4,16 +4,14 @@
 <dict>
     <key>Description</key>
     <string>Downloads latest VLC disk image and imports into Munki.
-        This recipe defaults supported_architectures to x86_64. 
-        If you override SPARKLE_FEED_URL to 
-        "https://update.videolan.org/vlc/sparkle/vlc-intel64.xml", be sure to
-        adjust ARCH to "arm64".</string>
+
+This recipe defaults supported_architectures to both "x86_64" and "arm64" for
+the Universal download of VLC. If you override the default ARCHITECTURE value,
+also remember to adjust the supported_architectures in your override.</string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.VLC</string>
     <key>Input</key>
     <dict>
-        <key>ARCH</key>
-        <string>x86_64</string>
         <key>NAME</key>
         <string>VLC</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -26,6 +24,8 @@
             </array>
             <key>description</key>
             <string>VLC is a free and open source cross-platform multimedia player and framework that plays most multimedia files as well as DVD, Audio CD, VCD, and various streaming protocols.</string>
+            <key>developer</key>
+            <string>The VideoLAN Project</string>
             <key>display_name</key>
             <string>VLC Media Player</string>
             <key>name</key>
@@ -34,20 +34,17 @@
             <true/>
             <key>supported_architectures</key>
             <array>
-                <string>%ARCH%</string>
+                <string>arm64</string>
+                <string>x86_64</string>
             </array>
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.4.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.VLC</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
## Summary

As noted in https://github.com/autopkg/recipes/issues/381, VLC now offers a Universal download version for supporting both Intel and Apple Silicon architectures. Switching to this version in our VLC recipes will provide better default compatibility for AutoPkg users wishing to provide VLC to their Macs.

## Details

This pull request includes:

### URLTextSearcher instead of SparkleUpdateInfoProvider

Unfortunately, there does not (yet) appear to be a dedicated Sparkle feed for the Universal version, so in order to programmatically download the Universal version URLTextSearcher is needed. Along with this change, the `SPARKLE_FEED_URL` input variable has been removed.

### `ARCHITECTURE` input variable

An `ARCHITECTURE` input variable has been added. (I avoided the shorthand `ARCH` because it's already used in the Munki recipe with a mutually exclusive set of values.) This input variable allows administrators to create two separate overrides for Intel and Apple Silicon builds of VLC, if they prefer the disk space savings over Universal compatibility.

```
autopkg make-override VLC.download -n VLC_intel64.download
# Then adjust VLC_intel64.download to use ARCHITECTURE=intel64

autopkg make-override VLC.download -n VLC_arm64.download
# Then adjust VLC_arm64.download to use ARCHITECTURE=arm64
```

| *IMPORTANT* |
| ----------- |
| *Administrators who run `autopkg repo-update recipes` and receive these changes will have a vestigial `SPARKLE_FEED_URL` variable in their override. This PR's changes are designed such that they'll get the Universal version, which will satisfy the majority of users' needs. <br /><br /> However, if administrators intentionally overrode the `SPARKLE_FEED_URL` to use the Apple Silicon feed, they'll need to manually update their override to contain an `ARCHITECTURE` variable in order to continue that behavior. (If they don't, they'll get the Universal version, which should do no harm other than taking up excess disk space.)* |

### New Munki `supported_architectures`

The previous version of the Munki recipe included an `ARCH` variable that would fill an entry in the `supported_architectures` pkginfo key. In order to allow multiple `supported_architectures` entries for the Universal version, that variable has been removed. Administrators who have customized the `ARCH` value will need to edit the `supported_architectures` array directly in their override. The default value for `supported_architectures` contains both `arm64` and `x86_64` for the Universal version of the VLC download.

### Munki developer

The developer, `The VideoLAN Project`, has been added to the Munki recipe.

## Testing output

Output from test runs follows:

### Download recipe run

```
% autopkg run -vv VLC/VLC.download.recipe 
Processing VLC/VLC.download.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="\\/\\/get\\.videolan\\.org\\/vlc\\/([\\d\\.]+)\\/macosx\\/vlc-[\\d\\.]+-universal\\.dmg"',
           'result_output_var_name': 'version',
           'url': 'https://www.videolan.org/vlc/download-macosx.html'}}
URLTextSearcher: Found matching text (version): 3.0.16
{'Output': {'version': '3.0.16'}}
URLDownloader
{'Input': {'filename': 'VLC-3.0.16.dmg',
           'url': 'https://get.videolan.org/vlc/3.0.16/macosx/vlc-3.0.16-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 18 Jun 2021 20:03:21 GMT
URLDownloader: Storing new ETag header: "60ccfc09-4d33fb5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.download.VLC/downloads/VLC-3.0.16.dmg
{'Output': {'download_changed': True,
            'etag': '"60ccfc09-4d33fb5"',
            'last_modified': 'Fri, 18 Jun 2021 20:03:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.download.VLC/downloads/VLC-3.0.16.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.download.VLC/downloads/VLC-3.0.16.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.download.VLC/downloads/VLC-3.0.16.dmg/VLC.app',
           'requirement': 'anchor apple generic and identifier '
                          '"org.videolan.vlc" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "75GAHG3SZQ")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.download.VLC/downloads/VLC-3.0.16.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.WtJoAH/VLC.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.WtJoAH/VLC.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.WtJoAH/VLC.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.download.VLC/receipts/VLC.download-receipt-20211015-094135.plist

The following new items were downloaded:
    Download Path                                                                                  
    -------------                                                                                  
    ~/Library/AutoPkg/Cache/com.github.autopkg.download.VLC/downloads/VLC-3.0.16.dmg  
```

### Initial Munki recipe run

```
% autopkg run -vv VLC/VLC.munki.recipe MakeCatalogs.munki
Processing VLC/VLC.munki.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="\\/\\/get\\.videolan\\.org\\/vlc\\/([\\d\\.]+)\\/macosx\\/vlc-[\\d\\.]+-universal\\.dmg"',
           'result_output_var_name': 'version',
           'url': 'https://www.videolan.org/vlc/download-macosx.html'}}
URLTextSearcher: Found matching text (version): 3.0.16
{'Output': {'version': '3.0.16'}}
URLDownloader
{'Input': {'filename': 'VLC-3.0.16.dmg',
           'url': 'https://get.videolan.org/vlc/3.0.16/macosx/vlc-3.0.16-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg/VLC.app',
           'requirement': 'anchor apple generic and identifier '
                          '"org.videolan.vlc" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "75GAHG3SZQ")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.WDU7k3/VLC.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.WDU7k3/VLC.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.WDU7k3/VLC.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'VLC is a free and open source '
                                      'cross-platform multimedia player and '
                                      'framework that plays most multimedia '
                                      'files as well as DVD, Audio CD, VCD, '
                                      'and various streaming protocols.',
                       'display_name': 'VLC Media Player',
                       'name': 'VLC',
                       'supported_architectures': ['arm64', 'x86_64'],
                       'unattended_install': True},
           'repo_subdirectory': 'apps/VLC'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/VLC/VLC-3.0.16.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/VLC/VLC-3.0.16.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'VLC',
                                                       'pkg_repo_path': 'apps/VLC/VLC-3.0.16.dmg',
                                                       'pkginfo_path': 'apps/VLC/VLC-3.0.16.plist',
                                                       'version': '3.0.16'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2021, 10, 14, 8, 43, 51),
                                         'munki_version': '5.5.0.4360',
                                         'os_version': '11.6'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'VLC is a free and open source '
                                          'cross-platform multimedia player '
                                          'and framework that plays most '
                                          'multimedia files as well as DVD, '
                                          'Audio CD, VCD, and various '
                                          'streaming protocols.',
                           'display_name': 'VLC Media Player',
                           'installer_item_hash': 'b95da70c95fc6b4581258867b9cd2f19a4c6b68f7a7474e23ba89659fd93f20f',
                           'installer_item_location': 'apps/VLC/VLC-3.0.16.dmg',
                           'installer_item_size': 79055,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'org.videolan.vlc',
                                         'CFBundleName': 'VLC media player',
                                         'CFBundleShortVersionString': '3.0.16',
                                         'CFBundleVersion': '3.0.16',
                                         'minosversion': '10.7.5',
                                         'path': '/Applications/VLC.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'VLC.app'}],
                           'minimum_os_version': '10.7.5',
                           'name': 'VLC',
                           'supported_architectures': ['arm64', 'x86_64'],
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.0.16'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/VLC/VLC-3.0.16.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/VLC/VLC-3.0.16.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/receipts/VLC.munki-receipt-20211014-014351.plist
Processing MakeCatalogs.munki...
MakeCatalogsProcessor
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo'}}
MakeCatalogsProcessor: Munki catalogs rebuilt!
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/local.munki.MakeCatalogs/receipts/MakeCatalogs-receipt-20211014-014354.plist

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path               Pkg Repo Path            Icon Repo Path
    ----  -------  --------  ------------               -------------            --------------
    VLC   3.0.16   testing   apps/VLC/VLC-3.0.16.plist  apps/VLC/VLC-3.0.16.dmg
```

### Subsequent Munki recipe run

```
% autopkg run -vv VLC/VLC.munki.recipe MakeCatalogs.munki
Processing VLC/VLC.munki.recipe...
Failed.
Receipt written to /tmp/receipts/VLC.munki-receipt-20211014-014056.plist
Processing MakeCatalogs.munki...
MakeCatalogsProcessor
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo'}}
MakeCatalogsProcessor: No need to rebuild catalogs.
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/local.munki.MakeCatalogs/receipts/MakeCatalogs-receipt-20211014-014100.plist

The following recipes failed:
    VLC/VLC.munki.recipe
        MunkiPkginfoMerger requires missing argument additional_pkginfo

Nothing downloaded, packaged or imported.
✘70 recipes % autopkg run -vv VLC/VLC.munki.recipe MakeCatalogs.munki
Processing VLC/VLC.munki.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="\\/\\/get\\.videolan\\.org\\/vlc\\/([\\d\\.]+)\\/macosx\\/vlc-[\\d\\.]+-universal\\.dmg"',
           'result_output_var_name': 'version',
           'url': 'https://www.videolan.org/vlc/download-macosx.html'}}
URLTextSearcher: Found matching text (version): 3.0.16
{'Output': {'version': '3.0.16'}}
URLDownloader
{'Input': {'filename': 'VLC-3.0.16.dmg',
           'url': 'https://get.videolan.org/vlc/3.0.16/macosx/vlc-3.0.16-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 18 Jun 2021 20:03:21 GMT
URLDownloader: Storing new ETag header: "60ccfc09-4d33fb5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg
{'Output': {'download_changed': True,
            'etag': '"60ccfc09-4d33fb5"',
            'last_modified': 'Fri, 18 Jun 2021 20:03:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg/VLC.app',
           'requirement': 'anchor apple generic and identifier '
                          '"org.videolan.vlc" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "75GAHG3SZQ")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.u06cHp/VLC.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.u06cHp/VLC.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.u06cHp/VLC.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'VLC is a free and open source '
                                      'cross-platform multimedia player and '
                                      'framework that plays most multimedia '
                                      'files as well as DVD, Audio CD, VCD, '
                                      'and various streaming protocols.',
                       'display_name': 'VLC Media Player',
                       'name': 'VLC',
                       'supported_architectures': ['arm64', 'x86_64'],
                       'unattended_install': True},
           'repo_subdirectory': 'apps/VLC'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Item VLC-3.0.16.dmg already exists in the munki repo as pkgs/apps/VLC-3.0.16.dmg.
{'Output': {'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/VLC-3.0.16.dmg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/receipts/VLC.munki-receipt-20211014-014225.plist
Processing MakeCatalogs.munki...
MakeCatalogsProcessor
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo'}}
MakeCatalogsProcessor: No need to rebuild catalogs.
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/local.munki.MakeCatalogs/receipts/MakeCatalogs-receipt-20211014-014227.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.autopkg.munki.VLC/downloads/VLC-3.0.16.dmg
```

### Pkg recipe run

```
Processing VLC/VLC.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="\\/\\/get\\.videolan\\.org\\/vlc\\/([\\d\\.]+)\\/macosx\\/vlc-[\\d\\.]+-universal\\.dmg"',
           'result_output_var_name': 'version',
           'url': 'https://www.videolan.org/vlc/download-macosx.html'}}
URLTextSearcher: Found matching text (version): 3.0.16
{'Output': {'version': '3.0.16'}}
URLDownloader
{'Input': {'filename': 'VLC-3.0.16.dmg',
           'url': 'https://get.videolan.org/vlc/3.0.16/macosx/vlc-3.0.16-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 18 Jun 2021 20:03:21 GMT
URLDownloader: Storing new ETag header: "60ccfc09-4d33fb5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg
{'Output': {'download_changed': True,
            'etag': '"60ccfc09-4d33fb5"',
            'last_modified': 'Fri, 18 Jun 2021 20:03:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg/VLC.app',
           'requirement': 'anchor apple generic and identifier '
                          '"org.videolan.vlc" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "75GAHG3SZQ")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ov8Mmr/VLC.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ov8Mmr/VLC.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ov8Mmr/VLC.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg
AppDmgVersioner: BundleID: org.videolan.vlc
AppDmgVersioner: Version: 3.0.16
{'Output': {'app_name': 'VLC.app',
            'bundleid': 'org.videolan.vlc',
            'version': '3.0.16'}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/VLC'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/VLC
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/VLC/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/VLC/Applications/VLC.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg/VLC.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg, dmg: .dmg/, dmg_source_path: VLC.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg
Copier: Copied /private/tmp/dmg.qUHlnq/VLC.app to ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/VLC/Applications/VLC.app
{'Output': {}}
PkgInfoCreator
{'Input': {'infofile': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/PackageInfo',
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/VLC',
           'pkgtype': 'flat',
           'template_path': 'PackageInfoTemplate',
           'version': '3.0.16'}}
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'org.videolan.vlc.pkg',
                           'options': 'purge_ds_store',
                           'pkgdir': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC',
                           'pkgname': 'VLC-3.0.16',
                           'resources': 'Resources'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'org.videolan.vlc.pkg',
                                                    'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/VLC-3.0.16.pkg',
                                                    'version': '3.0.16'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/VLC-3.0.16.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/receipts/VLC.pkg-receipt-20211015-094439.plist

The following new items were downloaded:
    Download Path                                                                             
    -------------                                                                             
    ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/downloads/VLC-3.0.16.dmg  

The following packages were built:
    Identifier            Version  Pkg Path                                                                        
    ----------            -------  --------                                                                        
    org.videolan.vlc.pkg  3.0.16   ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.VLC/VLC-3.0.16.pkg  
```

### Install recipe run

```
Processing VLC/VLC.install.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="\\/\\/get\\.videolan\\.org\\/vlc\\/([\\d\\.]+)\\/macosx\\/vlc-[\\d\\.]+-universal\\.dmg"',
           'result_output_var_name': 'version',
           'url': 'https://www.videolan.org/vlc/download-macosx.html'}}
URLTextSearcher: Found matching text (version): 3.0.16
{'Output': {'version': '3.0.16'}}
URLDownloader
{'Input': {'filename': 'VLC-3.0.16.dmg',
           'url': 'https://get.videolan.org/vlc/3.0.16/macosx/vlc-3.0.16-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 18 Jun 2021 20:03:21 GMT
URLDownloader: Storing new ETag header: "60ccfc09-4d33fb5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg
{'Output': {'download_changed': True,
            'etag': '"60ccfc09-4d33fb5"',
            'last_modified': 'Fri, 18 Jun 2021 20:03:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg/VLC.app',
           'requirement': 'anchor apple generic and identifier '
                          '"org.videolan.vlc" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "75GAHG3SZQ")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.e4afQZ/VLC.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.e4afQZ/VLC.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.e4afQZ/VLC.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
InstallFromDMG
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg',
           'download_changed': True,
           'items_to_copy': [{'destination_path': '/Applications/',
                              'source_item': 'VLC.app'}]}}
InstallFromDMG: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg
InstallFromDMG: Connecting
InstallFromDMG: Sending installation request
InstallFromDMG: STATUS:Copying VLC.app to /Applications/VLC.app
InstallFromDMG: Disconnecting
InstallFromDMG: Result: DONE
{'Output': {'install_from_dmg_summary_result': {'data': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg'},
                                                'summary_text': 'Items from '
                                                                'the following '
                                                                'disk images '
                                                                'were '
                                                                'successfully '
                                                                'installed:'},
            'install_result': 'DONE'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/receipts/VLC.install-receipt-20211015-094921.plist

The following new items were downloaded:
    Download Path                                                                                 
    -------------                                                                                 
    ~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg  

Items from the following disk images were successfully installed:
    Dmg Path                                                                                      
    --------                                                                                      
    ~/Library/AutoPkg/Cache/com.github.autopkg.install.VLC/downloads/VLC-3.0.16.dmg  
```
