### PR TITLE
Added download recipe for Company Portal

### DIFF
--- a/MSOfficeUpdates/MSCompanyPortal.download.recipe
+++ b/MSOfficeUpdates/MSCompanyPortal.download.recipe
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest Microsoft Company Portal pkg,
+and appends the version to the end of the filename.
+
+CHANNEL can be set to several values in order to get more frequent updates
+that can be used for testing purposes. See the explanations in the 'Channel'
+table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
+values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
+inserted into the Base URL.
+
+LOCALE_ID sets the locale for a descriptive text that will be
+extracted from the Microsoft update metadata. See
+https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
+for more information about locale IDs.
+
+VERSION supports three values: 'latest', which will download
+the latest full update for the given CHANNEL, 'latest-delta',
+which will download the latest delta update for the given CHANNEL,
+and 'latest-standalone' which will download the latest standalone
+installer for the given CHANNEL. 'latest-standalone' does not support
+'InsiderFast' CHANNEL.
+</string>
+    <key>Identifier</key>
+    <string>com.github.autopkg.download.MSCompanyPortal</string>
+    <key>MinimumVersion</key>
+    <string>1.4</string>
+    <key>Input</key>
+    <dict>
+        <key>CHANNEL</key>
+        <string>Production</string>
+        <key>LOCALE_ID</key>
+        <string>1033</string>
+        <key>NAME</key>
+        <string>CompanyPortal</string>
+        <key>PRODUCT</key>
+        <string>CompanyPortal</string>
+        <key>VERSION</key>
+        <string>latest</string>
+    </dict>
+    <key>ParentRecipe</key>
+    <string>com.github.autopkg.download.MSOfficeMacProduct</string>
+</dict>
+</plist>

--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -112,6 +112,11 @@ PROD_DICT = {
         "path": "/Applications/Microsoft Teams.app",
         "minimum_os": "10.10",
     },
+    "CompanyPortal": {
+        "id": "IMCP01",
+        "path": "/Applications/Company Portal.app",
+        "minimum_os": "10.15",
+    },
 }
 LOCALE_ID_INFO_URL = "https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx"
 SUPPORTED_VERSIONS = ["latest", "latest-delta", "latest-standalone"]
@@ -122,7 +127,7 @@ CHANNELS = {
     "InsiderFast": "4B2D7701-0A4F-49C8-B4CB-0C2D4043F51F",
 }
 DEFAULT_CHANNEL = "Production"
-NO_TRIGGER_CONDITIONS = ["SkypeForBusiness", "Teams", "Edge"]
+NO_TRIGGER_CONDITIONS = ["SkypeForBusiness", "Teams", "Edge", "CompanyPortal"]
 
 
 class MSOfficeMacURLandUpdateInfoProvider(URLGetter):


### PR DESCRIPTION
This PR adds the Microsoft Company Portal as an item to the product dictionary, and adds a download recipe to use with it as well.

Like Skype for Business and Teams, the Company Portal XML doesn't contain any triggers, so I've added it to the `NO_TRIGGER_CONDITIONS` list.

Output of `autopkg run -v MSCompanyPortal.download.recipe`:

```
Processing MSCompanyPortal.download.recipe...
WARNING: MSCompanyPortal.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MSOfficeMacURLandUpdateInfoProvider
MSOfficeMacURLandUpdateInfoProvider: Requesting xml: https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409IMCP01.xml
MSOfficeMacURLandUpdateInfoProvider: Found URL https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_5.2109.1-Upgrade.pkg
MSOfficeMacURLandUpdateInfoProvider: Got update: 'Company Portal Update 5.2109.1'
MSOfficeMacURLandUpdateInfoProvider: Extracting version 52.2110852.000 from metadata 'Update Version' key
MSOfficeMacURLandUpdateInfoProvider: Extracting version 52.2110852.000 from metadata 'Update Version' key
MSOfficeMacURLandUpdateInfoProvider: Additional pkginfo: {'minimum_os_version': '10.15', 'installs': [{'CFBundleVersion': '52.2110852.000', 'path': '/Applications/Company Portal.app', 'type': 'application'}]}
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 20 Oct 2021 17:46:11 GMT
URLDownloader: Storing new ETag header: "689ba5fdac5d71:0"
URLDownloader: Downloaded /Users/jc0b/Library/AutoPkg/Cache/com.github.autopkg.download.MSCompanyPortal/downloads/CompanyPortal-52.2110852.000.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "CompanyPortal-52.2110852.000.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-10-19 20:10:10 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Microsoft Corporation (UBF8T346G9)
CodeSignatureVerifier:        Expires: 2023-05-16 04:46:41 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            6A 66 CD 33 B5 5B 9C 14 86 02 29 09 DB 7E 00 85 53 11 29 6B CE 11
CodeSignatureVerifier:            9F 2A 93 5C 69 BF 56 3A 79 82
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
Receipt written to /Users/jc0b/Library/AutoPkg/Cache/com.github.autopkg.download.MSCompanyPortal/receipts/MSCompanyPortal.download-receipt-20211027-225030.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/jc0b/Library/AutoPkg/Cache/com.github.autopkg.download.MSCompanyPortal/downloads/CompanyPortal-52.2110852.000.pkg
```