### PR TITLE
Fix for cli tool path, new install recipe for TextMate2

### DIFF
--- a/TextMate/TextMate2.install.recipe
+++ b/TextMate/TextMate2.install.recipe
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Installs the latest TextMate 2 from GitHub</string>
+    <key>Identifier</key>
+    <string>com.github.autopkg.install.TextMate2</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>TextMate2</string>
+        <key>PRERELEASE</key>
+        <string></string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.autopkg.download.TextMate2</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>InstallFromDMG</string>
+            <key>Arguments</key>
+            <dict>
+                <key>items_to_copy</key>
+                <array>
+                    <dict>
+                        <key>source_item</key>
+                        <string>TextMate.app</string>
+                        <key>destination_path</key>
+                        <string>/Applications/</string>
+                    </dict>
+                </array>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/TextMate/TextMate2.munki.recipe
+++ b/TextMate/TextMate2.munki.recipe
@@ -38,7 +38,7 @@ i.e.: `-k PRERELEASE=yes`
             <key>postinstall_script</key>
             <string>#!/bin/sh
 [ -d /usr/local/bin ] || mkdir -p /usr/local/bin
-/bin/cp -f -p /Applications/TextMate.app/Contents/Resources/mate /usr/local/bin/mate
+/bin/cp -f -p /Applications/TextMate.app/Contents/MacOS/mate /usr/local/bin/mate
 </string>
             <key>postuninstall_script</key>
             <string>#!/bin/sh


### PR DESCRIPTION
Noticed path to mate is updated.
For install variant creates dmg before running install, should match convention when it comes to recipe naming and I didn't even swap spaces for tabs 😜 
gist with (install) run output:
https://gist.github.com/arubdesu/195bdfb1cf941a57745ee5df8114556e