### PR TITLE
Update to use CFBundleVersion with Skype

### DIFF
--- a/Skype/Skype.pkg.recipe
+++ b/Skype/Skype.pkg.recipe
@@ -18,8 +18,27 @@
 	<key>Process</key>
 	<array>
 		<dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%pathname%/Skype.app</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleVersion</key>
+                    <string>version</string>
+                </dict>
+            </dict>
+    	</dict>
+		<dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
+			<key>Arguments</key>
+            <dict>
+                <key>pkgname</key>
+                <string>%NAME%-%version%</string>
+			</dict>
 		</dict>
 	</array>
 </dict>

--- a/Skype/Skype.pkg.recipe
+++ b/Skype/Skype.pkg.recipe
@@ -17,29 +17,29 @@
 	<string>com.github.autopkg.download.Skype</string>
 	<key>Process</key>
 	<array>
-		<dict>
-            <key>Processor</key>
-            <string>PlistReader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>info_path</key>
-                <string>%pathname%/Skype.app</string>
-                <key>plist_keys</key>
+	    <dict>
+                <key>Processor</key>
+            	<string>PlistReader</string>
+           	<key>Arguments</key>
                 <dict>
-                    <key>CFBundleVersion</key>
-                    <string>version</string>
+                    <key>info_path</key>
+                    <string>%pathname%/Skype.app</string>
+                    <key>plist_keys</key>
+                    <dict>
+                        <key>CFBundleVersion</key>
+                        <string>version</string>
+                    </dict>
                 </dict>
-            </dict>
-    	</dict>
-		<dict>
-			<key>Processor</key>
-			<string>AppPkgCreator</string>
-			<key>Arguments</key>
-            <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
-			</dict>
-		</dict>
+    	    </dict>
+	    <dict>
+	        <key>Processor</key>
+		<string>AppPkgCreator</string>
+		<key>Arguments</key>
+                <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
+	        </dict>
+	    </dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Update to use CFBundleVersion with Skype for correct version as CFBundleShortVersionString does not include point updates.