### PR TITLE
MakeCatalogs: Check for munki_repo_changed

### DIFF
--- a/Munki/MakeCatalogsProcessor.py
+++ b/Munki/MakeCatalogsProcessor.py
@@ -63,7 +63,7 @@ class MakeCatalogsProcessor(Processor):
         except (IOError, OSError):
             run_results = []
 
-        something_imported = False
+        repo_changed = False
         # run_results is an array of autopackager.results,
         # which is itself an array.
         # look through all the results for evidence that
@@ -72,12 +72,12 @@ class MakeCatalogsProcessor(Processor):
         # but might be harder to grasp...
         for result in run_results:
             for item in result:
-                if item.get("Processor") == "MunkiImporter":
-                    if item["Output"].get("pkginfo_repo_path"):
-                        something_imported = True
-                        break
+                if ("Output" in item and
+                        item["Output"].get("munki_repo_changed", False)):
+                    repo_changed = True
+                    break
 
-        if not something_imported and not self.env.get("force_rebuild"):
+        if not repo_changed and not self.env.get("force_rebuild"):
             self.output("No need to rebuild catalogs.")
             self.env["makecatalogs_resultcode"] = 0
             self.env["makecatalogs_stderr"] = ""


### PR DESCRIPTION
Instead of relying exclusively on the output variable "pkginfo_repo_path" of the MunkiImporter processor, we use the more generic "munki_repo_changed" output variable which may be set by any processors.

Since the MunkiImporter processor also sets this variable as defined [here](https://github.com/autopkg/autopkg/blob/60781c3a79e389bb7aa1eca8664f40405525433b/Code/autopkglib/MunkiImporter.py#L149), this should have no negative impact on existing workflows.

This pull requests addresses #418.