### PR TITLE
AdobeReaderURLProvider.py and AdobeReaderDC.download refactor

### DIFF
--- a/AdobeReader/AdobeReaderDC.download.recipe
+++ b/AdobeReader/AdobeReaderDC.download.recipe
@@ -3,19 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>For OS_Version, 10.14.0 or 10.15.0 are valid, not 10.14 or 10.15</string>
+	<string>For OS_VERSION, 'Mac OS 10.14.0' or 'Mac OS 10.15.0' are valid, not 10.14 or 10.15</string>
     <key>Description</key>
-    <string>Downloads the latest Adobe Reader DC.</string>
+    <string>Downloads the latest Adobe Acrobat Reader DC.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.download.AdobeReaderDC</string>
 	<key>Input</key>
 	<dict>
-		<key>LANGUAGE</key>
-		<string>English</string>
-		<key>MAJOR_VERSION</key>
-		<string>AcrobatDC</string>
 		<key>OS_VERSION</key>
-		<string>10.15.0</string>
+		<string>Mac OS 10.14.0</string>
 	    <key>NAME</key>
 	    <string>AdobeReaderDC</string>
 	</dict>
@@ -26,10 +22,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>language</key>
-                <string>%LANGUAGE%</string>
-                <key>major_version</key>
-                <string>%MAJOR_VERSION%</string>
                 <key>os_version</key>
                 <string>%OS_VERSION%</string>
             </dict>
@@ -37,11 +29,6 @@
             <string>AdobeReaderURLProvider</string>
         </dict>
         <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%-%version%.dmg</string>
-            </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
         </dict>

--- a/AdobeReader/AdobeReaderDC.download.recipe
+++ b/AdobeReader/AdobeReaderDC.download.recipe
@@ -4,53 +4,53 @@
 <dict>
 	<key>Comment</key>
 	<string>For OS_VERSION, 'Mac OS 10.14.0' or 'Mac OS 10.15.0' are valid, not 10.14 or 10.15</string>
-    <key>Description</key>
-    <string>Downloads the latest Adobe Acrobat Reader DC.</string>
+	<key>Description</key>
+	<string>Downloads the latest Adobe Acrobat Reader DC.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.download.AdobeReaderDC</string>
 	<key>Input</key>
 	<dict>
+		<key>NAME</key>
+		<string>AdobeReaderDC</string>
 		<key>OS_VERSION</key>
 		<string>Mac OS 10.14.0</string>
-	    <key>NAME</key>
-	    <string>AdobeReaderDC</string>
 	</dict>
-    <key>MinimumVersion</key>
-    <string>1.4</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>os_version</key>
-                <string>%OS_VERSION%</string>
-            </dict>
-            <key>Processor</key>
-            <string>AdobeReaderURLProvider</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%pathname%/*.pkg</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: Adobe Inc. (JQ525L2MZD)</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
-            </dict>
-        </dict>
-    </array>
+	<key>MinimumVersion</key>
+	<string>1.4</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>os_version</key>
+				<string>%OS_VERSION%</string>
+			</dict>
+			<key>Processor</key>
+			<string>AdobeReaderURLProvider</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Adobe Inc. (JQ525L2MZD)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%/*.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/AdobeReader/AdobeReaderURLProvider.py
+++ b/AdobeReader/AdobeReaderURLProvider.py
@@ -95,6 +95,12 @@ class AdobeReaderURLProvider(URLGetter):
         base_url = self.env.get("base_url", RDC_PRODUCTS_URL)
         rdc_download_url = self.env.get("download_url", RDC_DOWNLOAD_URL)
         os_version = self.env.get("os_version", OS_VERSION_DEFAULT)
+        if not os_version.startswith("Mac OS"):
+            self.output(
+                "WARNING: Please update the OS_VERSION in your override "
+                f"from '{os_version}' to 'Mac OS {os_version}'"
+            )
+            os_version = f"Mac OS {os_version}"
         # Quote those os_version to make it a URL safe string
         os_version = quote(os_version)
         display_name, self.env["version"] = self.get_reader_download_info(

--- a/AdobeReader/AdobeReaderURLProvider.py
+++ b/AdobeReader/AdobeReaderURLProvider.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright 2010 Per Olofsson
+#           2021 Nate Felton <n8felton>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,91 +18,92 @@
 
 import json
 
-from autopkglib import APLooseVersion, ProcessorError
+from urllib.parse import quote
 from autopkglib.URLGetter import URLGetter
 
 __all__ = ["AdobeReaderURLProvider"]
 
-AR_BASE_URL = (
-    "http://get.adobe.com/reader/webservices/json/standalone/"
-    "?platform_type=Macintosh&platform_dist=OSX&platform_arch=x86-32"
-    "&platform_misc=%s&language=%s&eventname=readerotherversions"
-)
+# https://rdc.adobe.io/reader/products?os=Mac%20OS%2010.14.0&api_key=dc-get-adobereader-cdn
+# {"products":{"reader":[{"displayName":"Reader DC 2022.001.20112 for Mac","fileSize":327.5,"version":"22.001.20112"}],"dcPro":[]},"addons":[]}
+RDC_PRODUCTS_URL = "https://rdc.adobe.io/reader/products?os={OS_VERSION}&api_key=dc-get-adobereader-cdn"
+# https://rdc.adobe.io/reader/downloadUrl?name=Reader%20DC%202022.001.20112%20for%20Mac&os=Mac%20OS%2010.14.0&api_key=dc-get-adobereader-cdn
+# {"downloadURL":"https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2200120112/AcroRdrDC_2200120112_MUI.dmg","installer":"standalone","saveName":"AcroRdrDC_2200120112_MUI.dmg"}
+RDC_DOWNLOAD_URL = "https://rdc.adobe.io/reader/downloadUrl?name={DISPLAY_NAME}&os={OS_VERSION}&api_key=dc-get-adobereader-cdn"
 
-LANGUAGE_DEFAULT = "English"
-MAJOR_VERSION_DEFAULT = "AcrobatDC"
-OS_VERSION_DEFAULT = "10.15.0"
-
-MAJOR_VERSION_MATCH_STR = "adobe/reader/mac/%s"
+OS_VERSION_DEFAULT = "Mac OS 10.14.0"
 
 
 class AdobeReaderURLProvider(URLGetter):
-    """Provides URL to the latest Adobe Reader release."""
+    """Provides URL to the latest Adobe Acrobat Reader DC release."""
 
     description = __doc__
     input_variables = {
-        "language": {
-            "required": False,
-            "description": (
-                "Which language to download. Examples: 'English', "
-                "'German', 'Japanese', 'Swedish'. Default is %s." % LANGUAGE_DEFAULT
-            ),
-        },
         "os_version": {
             "required": False,
             "description": (
-                "macOS version to use in URL search. Defaults to %s."
-                " Reader DC requires '10.9.0'" % OS_VERSION_DEFAULT
+                f"macOS version to use in URL search. Defaults to '{OS_VERSION_DEFAULT}'."
             ),
         },
-        "major_version": {
+        "base_url": {
             "required": False,
-            "description": (
-                "Major version. Examples: '10', '11', 'AcrobatDC'. "
-                "Defaults to %s" % MAJOR_VERSION_DEFAULT
-            ),
+            "description": f"Default is {RDC_PRODUCTS_URL}",
         },
-        "base_url": {"required": False, "description": "Default is %s" % AR_BASE_URL},
+        "download_url": {
+            "required": False,
+            "description": f"Default is {RDC_DOWNLOAD_URL}",
+        },
     }
     output_variables = {
-        "url": {"description": "URL to the latest Adobe Reader release."},
-        "version": {"description": "Version of the latest Adobe Reader release."},
+        "url": {"description": "URL to the latest Adobe Acrobat Reader DC release."},
+        "filename": {
+            "description": "The Adobe provided filename to save the download as."
+        },
+        "version": {
+            "description": "Version of the latest Adobe Acrobat Reader DC release."
+        },
     }
 
-    def get_reader_dmg_info(self, base_url, language, major_version, os_version):
-        """Returns download URL for Adobe Reader DMG"""
-        request_url = base_url % (os_version, language)
-        header = {"x-requested-with": "XMLHttpRequest"}
-        json_response = self.download(request_url, headers=header)
-
+    def get_reader_download_info(self, base_url, os_version):
+        """Returns information required to download Adobe Acrobat Reader DC"""
+        request_url = base_url.format(OS_VERSION=os_version)
+        self.output(f"RDC_PRODUCTS_URL: {request_url}", 3)
+        json_response = self.download(request_url)
         reader_info = json.loads(json_response)
-        major_version_string = MAJOR_VERSION_MATCH_STR % major_version
-        matches = {
-            item["Version"]: item["download_url"]
-            for item in reader_info
-            if major_version_string in item["download_url"]
-        }
-        try:
-            version = max(matches, key=lambda x: APLooseVersion(x))
-            return matches[version], version
-        except IndexError:
-            raise ProcessorError(
-                "Can't find Adobe Reader download URL for %s, version %s"
-                % (language, major_version)
-            )
+        self.output(reader_info, 3)
+        display_name = reader_info["products"]["reader"][0]["displayName"]
+        version = reader_info["products"]["reader"][0]["version"]
+        self.output(f"[displayName] : {display_name}")
+        self.output(f"[version]     : {version}")
+        return display_name, version
+
+    def get_reader_download_url(self, rdc_download_url, os_version, display_name):
+        """Returns the download URL for the latest version of Adobe Acrobat Reader DC"""
+        rdc_download_url = rdc_download_url.format(
+            OS_VERSION=os_version, DISPLAY_NAME=display_name
+        )
+        self.output(f"RDC_DOWNLOAD_URL: {rdc_download_url}", 3)
+        json_response = self.download(rdc_download_url)
+        download_info = json.loads(json_response)
+        self.output(download_info, 3)
+        download_url = download_info["downloadURL"]
+        filename = download_info["saveName"]
+        self.output(f"[download_url]: {download_url}")
+        return download_url, filename
 
     def main(self):
-        # Determine base_url, language and major_version.
-        base_url = self.env.get("base_url", AR_BASE_URL)
-        language = self.env.get("language", LANGUAGE_DEFAULT)
-        major_version = self.env.get("major_version", MAJOR_VERSION_DEFAULT)
+        base_url = self.env.get("base_url", RDC_PRODUCTS_URL)
+        rdc_download_url = self.env.get("download_url", RDC_DOWNLOAD_URL)
         os_version = self.env.get("os_version", OS_VERSION_DEFAULT)
-
-        self.env["url"], self.env["version"] = self.get_reader_dmg_info(
-            base_url, language, major_version, os_version
+        # Quote those os_version to make it a URL safe string
+        os_version = quote(os_version)
+        display_name, self.env["version"] = self.get_reader_download_info(
+            base_url, os_version
         )
-        self.output("Found URL %s" % self.env["url"])
-        self.output("Found version %s" % self.env["version"])
+        # Quote those display_name to make it a URL safe string
+        display_name = quote(display_name)
+        self.env["url"], self.env["filename"] = self.get_reader_download_url(
+            rdc_download_url, os_version, display_name
+        )
 
 
 if __name__ == "__main__":

--- a/AdobeReader/AdobeReaderURLProvider.py
+++ b/AdobeReader/AdobeReaderURLProvider.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright 2010 Per Olofsson
-#           2021 Nate Felton <n8felton>
+#           2022 Nate Felton <n8felton>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AdobeReader/AdobeReaderURLProvider.py
+++ b/AdobeReader/AdobeReaderURLProvider.py
@@ -17,8 +17,8 @@
 """See docstring for AdobeReaderURLProvider class"""
 
 import json
-
 from urllib.parse import quote
+
 from autopkglib.URLGetter import URLGetter
 
 __all__ = ["AdobeReaderURLProvider"]
@@ -91,6 +91,7 @@ class AdobeReaderURLProvider(URLGetter):
         return download_url, filename
 
     def main(self):
+        """Main process"""
         base_url = self.env.get("base_url", RDC_PRODUCTS_URL)
         rdc_download_url = self.env.get("download_url", RDC_DOWNLOAD_URL)
         os_version = self.env.get("os_version", OS_VERSION_DEFAULT)


### PR DESCRIPTION
My attempt at fixing AdobeReaderURLProvider.py and the AdobeReaderDC.download recipe.

Rather than attempting to generate our own URLs using `ardownload` or `ardownload2`, this attempts to mimic the functionality of https://get.adobe.com/reader/otherversions which appears to offer some nice JSON data with the information we need for the latest version.

```shell
https://rdc.adobe.io/reader/products?os=Mac%20OS%2010.14.0&api_key=dc-get-adobereader-cdn
```
```json
{
  "products": {
    "reader": [
      {
        "displayName": "Reader DC 2022.001.20112 for Mac",
        "fileSize": 327.5,
        "version": "22.001.20112"
      }
    ],
    "dcPro": []
  },
  "addons": []
}

```
Capturing and using `displayName` in the second URL gets us our download URL.
```shell
https://rdc.adobe.io/reader/downloadUrl?name=Reader%20DC%202022.001.20112%20for%20Mac&os=Mac%20OS%2010.14.0&api_key=dc-get-adobereader-cdn
```
```json
{
  "downloadURL": "https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2200120112/AcroRdrDC_2200120112_MUI.dmg",
  "installer": "standalone",
  "saveName": "AcroRdrDC_2200120112_MUI.dmg"
}
```

`language` was removed as changing it to different languages (such as `es` and `jp` in my testing) did not produce any different results.

`major_version` was removed as it appears that DC is here to stay for a while and previous versions are no longer available for download.

`filename` was added as an output variable, derived from the `saveName` that is provided by Adobe.

Fixes #229 
Fixes #416 
Fixes #424
Fixes #426

```
autopkg run AdobeReader/AdobeReaderDC.download.recipe -vvvvv              
Processing AdobeReader/AdobeReaderDC.download.recipe...
WARNING: AdobeReader/AdobeReaderDC.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.4.1',
 'CACHE_DIR': '/usr/local/autopkg/cache',
 'MUNKI_REPO': '/Users/Shared/munki',
 'NAME': 'AdobeReaderDC',
 'OS_VERSION': 'Mac OS 10.14.0',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC',
 'RECIPE_DIR': '/Users/n8felton/src/autopkg/recipes/AdobeReader',
 'RECIPE_OVERRIDE_DIRS': ['/usr/local/autopkg/recipe_overrides'],
 'RECIPE_PATH': '/Users/n8felton/src/autopkg/recipes/AdobeReader/AdobeReaderDC.download.recipe',
 'RECIPE_REPOS': {'/usr/local/autopkg/recipe_repos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes.git'}},
 'RECIPE_REPO_DIR': '/usr/local/autopkg/recipe_repos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/usr/local/autopkg/recipe_repos/com.github.autopkg.n8felton-recipes'],
 'verbose': 5}
AdobeReaderURLProvider
{'Input': {'os_version': 'Mac OS 10.14.0'}}
AdobeReaderURLProvider: RDC_PRODUCTS_URL: https://rdc.adobe.io/reader/products?os=Mac%20OS%2010.14.0&api_key=dc-get-adobereader-cdn
AdobeReaderURLProvider: Curl command: ['/usr/local/bin/curl', '--compressed', '--location', 'https://rdc.adobe.io/reader/products?os=Mac%20OS%2010.14.0&api_key=dc-get-adobereader-cdn']
AdobeReaderURLProvider: {'products': {'reader': [{'displayName': 'Reader DC 2022.001.20112 for Mac', 'fileSize': 327.5, 'version': '22.001.20112'}], 'dcPro': []}, 'addons': []}
AdobeReaderURLProvider: [displayName] : Reader DC 2022.001.20112 for Mac
AdobeReaderURLProvider: [version]     : 22.001.20112
AdobeReaderURLProvider: RDC_DOWNLOAD_URL: https://rdc.adobe.io/reader/downloadUrl?name=Reader%20DC%202022.001.20112%20for%20Mac&os=Mac%20OS%2010.14.0&api_key=dc-get-adobereader-cdn
AdobeReaderURLProvider: Curl command: ['/usr/local/bin/curl', '--compressed', '--location', 'https://rdc.adobe.io/reader/downloadUrl?name=Reader%20DC%202022.001.20112%20for%20Mac&os=Mac%20OS%2010.14.0&api_key=dc-get-adobereader-cdn']
AdobeReaderURLProvider: {'downloadURL': 'https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2200120112/AcroRdrDC_2200120112_MUI.dmg', 'installer': 'standalone', 'saveName': 'AcroRdrDC_2200120112_MUI.dmg'}
AdobeReaderURLProvider: [download_url]: https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2200120112/AcroRdrDC_2200120112_MUI.dmg
{'Output': {'filename': 'AcroRdrDC_2200120112_MUI.dmg',
            'url': 'https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2200120112/AcroRdrDC_2200120112_MUI.dmg',
            'version': '22.001.20112'}}
URLDownloader
{'Input': {'filename': 'AcroRdrDC_2200120112_MUI.dmg',
           'url': 'https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2200120112/AcroRdrDC_2200120112_MUI.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Curl command: ['/usr/local/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2200120112/AcroRdrDC_2200120112_MUI.dmg', '--fail', '--output', '/usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/tmpt_5n2_xe']
URLDownloader: Storing new Last-Modified header: Mon, 11 Apr 2022 11:26:52 GMT
URLDownloader: Storing new ETag header: "13854259-5dc5f3895e4a3"
URLDownloader: Downloaded /usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/AcroRdrDC_2200120112_MUI.dmg
{'Output': {'download_changed': True,
            'etag': '"13854259-5dc5f3895e4a3"',
            'last_modified': 'Mon, 11 Apr 2022 11:26:52 GMT',
            'pathname': '/usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/AcroRdrDC_2200120112_MUI.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/AcroRdrDC_2200120112_MUI.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Adobe Inc. '
                                        '(JQ525L2MZD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/AcroRdrDC_2200120112_MUI.dmg/*.pkg'}}
CodeSignatureVerifier: Mounted disk image /usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/AcroRdrDC_2200120112_MUI.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.6E6Pmp/AcroRdrDC_2200120112_MUI.pkg' matched from globbed '/private/tmp/dmg.6E6Pmp/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AcroRdrDC_2200120112_MUI.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-04-04 23:56:59 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Adobe Inc. (JQ525L2MZD)
CodeSignatureVerifier:        Expires: 2025-03-20 15:53:03 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            EB A4 77 C5 66 4C 70 60 7B CD 99 73 19 24 5D FF 1A 94 85 A9 32 37 
CodeSignatureVerifier:            CE 14 9C FD 5C B9 1A 39 CA C5
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
{'AUTOPKG_VERSION': '2.4.1',
 'CACHE_DIR': '/usr/local/autopkg/cache',
 'CHECK_FILESIZE_ONLY': False,
 'MUNKI_REPO': '/Users/Shared/munki',
 'NAME': 'AdobeReaderDC',
 'OS_VERSION': 'Mac OS 10.14.0',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC',
 'RECIPE_DIR': '/Users/n8felton/src/autopkg/recipes/AdobeReader',
 'RECIPE_OVERRIDE_DIRS': ['/usr/local/autopkg/recipe_overrides'],
 'RECIPE_PATH': '/Users/n8felton/src/autopkg/recipes/AdobeReader/AdobeReaderDC.download.recipe',
 'RECIPE_REPOS': {'/usr/local/autopkg/recipe_repos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes.git'}},
 'RECIPE_REPO_DIR': '/usr/local/autopkg/recipe_repos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/usr/local/autopkg/recipe_repos/com.github.autopkg.n8felton-recipes'],
 'download_changed': True,
 'etag': '"13854259-5dc5f3895e4a3"',
 'expected_authority_names': ['Developer ID Installer: Adobe Inc. (JQ525L2MZD)',
                              'Developer ID Certification Authority',
                              'Apple Root CA'],
 'filename': 'AcroRdrDC_2200120112_MUI.dmg',
 'input_path': '/usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/AcroRdrDC_2200120112_MUI.dmg/*.pkg',
 'last_modified': 'Mon, 11 Apr 2022 11:26:52 GMT',
 'os_version': 'Mac OS 10.14.0',
 'pathname': '/usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/AcroRdrDC_2200120112_MUI.dmg',
 'prefetch_filename': False,
 'url': 'https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2200120112/AcroRdrDC_2200120112_MUI.dmg',
 'url_downloader_summary_result': {'data': {'download_path': '/usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/AcroRdrDC_2200120112_MUI.dmg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 5,
 'version': '22.001.20112'}
Receipt written to /usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/receipts/AdobeReaderDC.download-receipt-20220527-153913.plist

The following new items were downloaded:
    Download Path                                                                                              
    -------------                                                                                              
    /usr/local/autopkg/cache/com.github.autopkg.download.AdobeReaderDC/downloads/AcroRdrDC_2200120112_MUI.dmg
```