### PR TITLE
Upstream Corretto for easier maintenance

### DIFF
--- a/Amazon Corretto/AmazonCorrettoJDK.download.recipe
+++ b/Amazon Corretto/AmazonCorrettoJDK.download.recipe
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Description</key>
+        <string>Downloads the latest version of Amazon Corretto JDK. Requires ARCH (x64 [Intel], or aarch64 [Apple Silicon]) and MAJOR_VERSION (8,11,17,18).</string>
+        <key>Identifier</key>
+        <string>com.github.autopkg.download.amazoncorretto</string>
+        <key>Input</key>
+        <dict>
+            <key>NAME</key>
+            <string>Amazon Corretto %MAJOR_VERSION%</string>
+            <key>MAJOR_VERSION</key>
+            <string>8</string>
+            <key>ARCH</key>
+            <string>x64</string>
+        </dict>
+        <key>MinimumVersion</key>
+        <string>1.4.0</string>
+        <key>Process</key>
+        <array>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>architecture</key>
+                    <string>%ARCH%</string>
+                    <key>major_version</key>
+                    <string>%MAJOR_VERSION%</string>
+                </dict>
+                <key>Processor</key>
+                <string>CorrettoURLGetter</string>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>URLDownloader</string>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>EndOfCheckPhase</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>input_path</key>
+                    <string>%pathname%</string>
+                    <key>expected_authority_names</key>
+                    <array>
+                        <string>Developer ID Installer: AMZN Mobile LLC (94KV3E626L)</string>
+                        <string>Developer ID Certification Authority</string>
+                        <string>Apple Root CA</string>
+                    </array>
+                </dict>
+                <key>Processor</key>
+                <string>CodeSignatureVerifier</string>
+            </dict>
+        </array>
+    </dict>
+</plist>

--- a/Amazon Corretto/AmazonCorrettoJDK.install.recipe
+++ b/Amazon Corretto/AmazonCorrettoJDK.install.recipe
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Description</key>
+        <string>This recipe downloads the signed installer package that Mozilla made available starting in Firefox 69.0. Because the downloaded file is already a package, this pkg recipe does not add any further actions.
+
+Downloads the latest version of Amazon Corretto JDK. Requires ARCH (x64 [Intel], or aarch64 [Apple Silicon]) and MAJOR_VERSION (8,11,17,18).</string>
+        <key>Identifier</key>
+        <string>com.github.autopkg.install.amazoncorretto</string>
+        <key>Input</key>
+        <dict>
+            <key>NAME</key>
+            <string>Amazon Corretto %MAJOR_VERSION%</string>
+            <key>MAJOR_VERSION</key>
+            <string>8</string>
+            <key>ARCH</key>
+            <string>x64</string>
+        </dict>
+        <key>MinimumVersion</key>
+        <string>1.4.0</string>
+        <key>ParentRecipe</key>
+        <string>com.github.autopkg.download.amazoncorretto</string>
+        <key>Process</key>
+        <array>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>pkg_path</key>
+                    <string>%pathname%</string>
+                </dict>
+                <key>Processor</key>
+                <string>Installer</string>
+            </dict>
+        </array>
+    </dict>
+</plist>

--- a/Amazon Corretto/AmazonCorrettoJDK.munki.recipe
+++ b/Amazon Corretto/AmazonCorrettoJDK.munki.recipe
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Description</key>
+        <string>Downloads the latest version of Amazon Corretto JDK and imports it into Munki. Requires ARCH (x64 [Intel], or aarch64 [Apple Silicon]) and MAJOR_VERSION (8,11,17,18). Will also specify the supported_architecture for Munki</string>
+        <key>Identifier</key>
+        <string>com.github.autopkg.munki.amazoncorretto</string>
+        <key>Input</key>
+        <dict>
+            <key>NAME</key>
+            <string>Corretto%MAJOR_VERSION%</string>
+            <key>MAJOR_VERSION</key>
+            <string>8</string>
+            <key>ARCH</key>
+            <string>x64</string>
+            <key>MUNKI_REPO_SUBDIR</key>
+            <string>jdk</string>
+            <key>pkginfo</key>
+            <dict>
+                <key>catalogs</key>
+                <array>
+                    <string>testing</string>
+                </array>
+                <key>description</key>
+                <string>Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK).</string>
+                <key>display_name</key>
+                <string>Amazon Corretto %MAJOR_VERSION%</string>
+                <key>minimum_os_version</key>
+                <string>10.9</string>
+                <key>name</key>
+                <string>%NAME%</string>
+                <key>unattended_install</key>
+                <true/>
+            </dict>
+        </dict>
+        <key>MinimumVersion</key>
+        <string>2.0</string>
+        <key>ParentRecipe</key>
+        <string>com.github.autopkg.download.amazoncorretto</string>
+        <key>Process</key>
+        <array>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>additional_pkginfo</key>
+                    <dict>
+                        <key>version</key>
+                        <string>%version%</string>
+                        <key>supported_architectures</key>
+                        <string>%supported_architectures%</string>
+                    </dict>
+                </dict>
+                <key>Processor</key>
+                <string>MunkiPkginfoMerger</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>pkg_path</key>
+                    <string>%pathname%</string>
+                    <key>repo_subdirectory</key>
+                    <string>%MUNKI_REPO_SUBDIR%</string>
+                </dict>
+                <key>Processor</key>
+                <string>MunkiImporter</string>
+            </dict>
+        </array>
+    </dict>
+</plist>

--- a/Amazon Corretto/AmazonCorrettoJDK.pkg.recipe
+++ b/Amazon Corretto/AmazonCorrettoJDK.pkg.recipe
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Description</key>
+        <string>This recipe downloads the signed installer package from Amazon Corretto. Because the downloaded file is already a package, this pkg recipe does not add any further actions.
+
+Downloads the latest version of Amazon Corretto JDK. Requires ARCH (x64 [Intel], or aarch64 [Apple Silicon]) and MAJOR_VERSION (8,11,17,18).</string>
+        <key>Identifier</key>
+        <string>com.github.autopkg.pkg.amazoncorretto</string>
+        <key>Input</key>
+        <dict>
+            <key>NAME</key>
+            <string>Amazon Corretto %MAJOR_VERSION%</string>
+            <key>MAJOR_VERSION</key>
+            <string>8</string>
+            <key>ARCH</key>
+            <string>x64</string>
+        </dict>
+        <key>MinimumVersion</key>
+        <string>1.4.0</string>
+        <key>ParentRecipe</key>
+        <string>com.github.autopkg.download.amazoncorretto</string>
+        <key>Process</key>
+        <array/>
+    </dict>
+</plist>

--- a/Amazon Corretto/CorrettoURLGetter.py
+++ b/Amazon Corretto/CorrettoURLGetter.py
@@ -1,0 +1,59 @@
+#!/usr/local/autopkg/python
+
+import json
+
+from autopkglib import ProcessorError
+from autopkglib.URLGetter import URLGetter
+
+__all__ = ["CorrettoURLGetter"]
+
+
+class CorrettoURLGetter(URLGetter):
+    """
+    Downloads the latest indexmap for all corretto releases, provides url and version of choosen
+    major_version + architecture
+
+    Requires version 1.4.
+    """
+
+    input_variables = {
+        "corretto_indexmap_url": {
+            "required": False,
+            "description": "URL to indexmap of Corretto installers",
+            "default": "https://raw.githubusercontent.com/corretto/corretto-downloads/main/latest_links/indexmap_with_checksum.json",
+        },
+        "major_version": {
+            "required": True,
+            "description": "Major version of corretto to use: 8,11,17,18",
+        },
+        "architecture": {
+            "required": True,
+            "description": "Architecture to use, x64 or aarch64",
+        },
+    }
+    output_variables = {
+        "version": {"description": "Version of latest major version"},
+        "url": {"description": "Download URL for specified version and architecture"},
+        "supported_architectures": {
+            "description": "Converted to Munki supported architecture type"
+        },
+    }
+    description = __doc__
+
+    def main(self):
+        json_data = self.download(self.env["corretto_indexmap_url"])
+        self.output("Got latest indexmap")
+        indexmap = json.loads(json_data)
+        tail_url = indexmap["macos"][self.env["architecture"]]["jdk"][
+            self.env["major_version"]
+        ]["pkg"]["resource"]
+        self.env["url"] = f"https://corretto.aws{tail_url}"
+        self.env["version"] = tail_url.split("-", 3)[2]
+        self.env["supported_architectures"] = (
+            "x86_64" if self.env["architecture"] == "x64" else "arm64"
+        )
+
+
+if __name__ == "__main__":
+    PROCESSOR = CorrettoURLGetter()
+    PROCESSOR.execute_shell()


### PR DESCRIPTION
This creates an upstream primary recipe set that others can base overrides off instead of creating whole new recipes when versions come out. This (combined with notifying other repos) should help reduce all the corretto recipes around. 

This also supports the different architectures available to corretto downloads, and makes that work with Munki (should be validated by someone who uses it)