### PR TITLE
Add postuninstall_script to BBEdit.munki

### DIFF
--- a/Barebones/BBEdit.munki.recipe
+++ b/Barebones/BBEdit.munki.recipe
@@ -46,6 +46,20 @@ done
 "$LN" -sf "$HELPER_BIN_SRC_DIR/bbedit_tool" "$CMD_TOOL_DIR/bbedit"
 "$LN" -sf "$HELPER_MAN_SRC_DIR/bbedit.1" "$CMD_MAN_DIR/bbedit.1"
             </string>
+            <key>postuninstall_script</key>
+            <string>#!/bin/sh
+# Delete BBEdit command-line tool resources if they exist
+
+CMD_TOOL_DIR=/usr/local/bin
+CMD_MAN_DIR=/usr/local/share/man/man1
+RM=/bin/rm
+
+# Delete symlinks to binaries and man pages
+for TOOL in bbdiff bbfind bbresults bbedit; do
+	[ -e "$CMD_TOOL_DIR/$TOOL" ] && "$RM" "$CMD_TOOL_DIR/$TOOL"
+	[ -e "$CMD_MAN_DIR/$TOOL.1" ] && "$RM" "$CMD_MAN_DIR/$TOOL.1"
+done
+            </string>
             <key>unattended_install</key>
             <true/>
         </dict>

--- a/Barebones/BBEdit.munki.recipe
+++ b/Barebones/BBEdit.munki.recipe
@@ -56,8 +56,8 @@ RM=/bin/rm
 
 # Delete symlinks to binaries and man pages
 for TOOL in bbdiff bbfind bbresults bbedit; do
-	[ -e "$CMD_TOOL_DIR/$TOOL" ] && "$RM" "$CMD_TOOL_DIR/$TOOL"
-	[ -e "$CMD_MAN_DIR/$TOOL.1" ] && "$RM" "$CMD_MAN_DIR/$TOOL.1"
+	[ -e "$CMD_TOOL_DIR/$TOOL" ] &amp;&amp; "$RM" "$CMD_TOOL_DIR/$TOOL"
+	[ -e "$CMD_MAN_DIR/$TOOL.1" ] &amp;&amp; "$RM" "$CMD_MAN_DIR/$TOOL.1"
 done
             </string>
             <key>unattended_install</key>

--- a/Barebones/BBEdit_Scripts/postuninstall
+++ b/Barebones/BBEdit_Scripts/postuninstall
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Delete BBEdit command-line tool resources if they exist
+
+CMD_TOOL_DIR=/usr/local/bin
+CMD_MAN_DIR=/usr/local/share/man/man1
+RM=/bin/rm
+
+# Delete symlinks to binaries and man pages
+for TOOL in bbdiff bbfind bbresults bbedit; do
+	[ -e "$CMD_TOOL_DIR/$TOOL" ] && "$RM" "$CMD_TOOL_DIR/$TOOL"
+	[ -e "$CMD_MAN_DIR/$TOOL.1" ] && "$RM" "$CMD_MAN_DIR/$TOOL.1"
+done


### PR DESCRIPTION
Cleans up command line tool symlinks, added by the `postinstall_script`, if they exist when removing BBEdit