### PR TITLE
Add Thunderbird Signed pkg items

### DIFF
--- a/Mozilla/ThunderbirdSignedPkg.download.recipe
+++ b/Mozilla/ThunderbirdSignedPkg.download.recipe
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Description</key>
+		<string>This recipe downloads the signed installer package that Mozilla made available starting in Thunderbird 69.0 and 68.1esr.
+
+You may choose a specific release stream by placing the appropriate key in the
+LATEST_RELEASE input variable. The two most common are:
+	LATEST_THUNDERBIRD_VERSION for the latest (regular) release (this is the default), and
+Other values to try can be found by examining the JSON file at:
+	https://product-details.mozilla.org/1.0/thunderbird_versions.json
+(Not all will work.)
+
+LOCALE controls the language localization to be downloaded.
+Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
+See the following URL for possible LOCALE values:
+	http://ftp.mozilla.org/pub/thunderbird/releases/latest/README.txt
+</string>
+		<key>Identifier</key>
+		<string>com.github.autopkg.download.ThunderbirdSignedPkg</string>
+		<key>Input</key>
+		<dict>
+			<key>LOCALE</key>
+			<string>en-US</string>
+			<key>NAME</key>
+			<string>Thunderbird</string>
+			<key>LATEST_RELEASE</key>
+			<string>LATEST_THUNDERBIRD_VERSION</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>2.0</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>re_pattern</key>
+					<string>"%LATEST_RELEASE%": "([\d\.abesr]+)"</string>
+					<key>result_output_var_name</key>
+					<string>version</string>
+					<key>url</key>
+					<string>https://product-details.mozilla.org/1.0/thunderbird_versions.json</string>
+				</dict>
+				<key>Processor</key>
+				<string>URLTextSearcher</string>
+			</dict>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>filename</key>
+					<string>%NAME%-%version%.pkg</string>
+					<key>url</key>
+					<string>https://releases.mozilla.org/pub/thunderbird/releases/%version%/mac/%LOCALE%/Thunderbird%20%version%.pkg</string>
+				</dict>
+				<key>Processor</key>
+				<string>URLDownloader</string>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>EndOfCheckPhase</string>
+			</dict>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>expected_authority_names</key>
+					<array>
+						<string>Developer ID Installer: Mozilla Corporation (43AQ936H96)</string>
+						<string>Developer ID Certification Authority</string>
+						<string>Apple Root CA</string>
+					</array>
+					<key>input_path</key>
+					<string>%pathname%</string>
+				</dict>
+				<key>Processor</key>
+				<string>CodeSignatureVerifier</string>
+			</dict>
+		</array>
+	</dict>
+</plist>

--- a/Mozilla/ThunderbirdSignedPkg.install.recipe
+++ b/Mozilla/ThunderbirdSignedPkg.install.recipe
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Description</key>
+		<string>This recipe downloads the signed installer package that Mozilla made available starting in Thunderbird 69.0, and installs it locally onto the computer running AutoPkg.
+
+The RELEASE key used in the standard Thunderbird recipes are not yet supported.
+LOCALE controls the language localization to be downloaded.
+Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
+See the following URL for possible LOCALE values:
+	http://ftp.mozilla.org/pub/thunderbird/releases/latest/README.txt
+</string>
+		<key>Identifier</key>
+		<string>com.github.autopkg.install.ThunderbirdSignedPkg</string>
+		<key>Input</key>
+		<dict>
+			<key>RELEASE</key>
+			<string>latest</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>2.0</string>
+		<key>ParentRecipe</key>
+		<string>com.github.autopkg.download.ThunderbirdSignedPkg</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>pkg_path</key>
+					<string>%pathname%</string>
+				</dict>
+				<key>Processor</key>
+				<string>Installer</string>
+			</dict>
+		</array>
+	</dict>
+</plist>

--- a/Mozilla/ThunderbirdSignedPkg.munki.recipe
+++ b/Mozilla/ThunderbirdSignedPkg.munki.recipe
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Description</key>
+		<string>This recipe downloads the signed installer package that Mozilla made available starting in Thunderbird 69.0, and imports the pkg file into a Munki repo.
+
+The RELEASE key used in the standard Thunderbird recipes are not yet supported.
+LOCALE controls the language localization to be downloaded.
+Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
+See the following URL for possible LOCALE values:
+	http://ftp.mozilla.org/pub/thunderbird/releases/latest/README.txt
+</string>
+		<key>Identifier</key>
+		<string>com.github.autopkg.munki.ThunderbirdSignedPkg</string>
+		<key>Input</key>
+		<dict>
+			<key>MUNKI_REPO_SUBDIR</key>
+			<string>apps/thunderbird</string>
+			<key>NAME</key>
+			<string>Thunderbird</string>
+			<key>pkginfo</key>
+			<dict>
+				<key>blocking_applications</key>
+				<array>
+					<string>Thunderbird.app</string>
+				</array>
+				<key>catalogs</key>
+				<array>
+					<string>testing</string>
+				</array>
+				<key>description</key>
+				<string>Mozilla Thunderbird is a free and open-source cross-platform email client, personal information manager, news client, RSS and chat client.</string>
+				<key>display_name</key>
+				<string>Mozilla Thunderbird</string>
+				<key>minimum_os_version</key>
+				<string>10.9</string>
+				<key>name</key>
+				<string>%NAME%</string>
+				<key>unattended_install</key>
+				<true/>
+			</dict>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>2.0</string>
+		<key>ParentRecipe</key>
+		<string>com.github.autopkg.download.ThunderbirdSignedPkg</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>additional_pkginfo</key>
+					<dict>
+						<key>version</key>
+						<string>%version%</string>
+					</dict>
+				</dict>
+				<key>Processor</key>
+				<string>MunkiPkginfoMerger</string>
+			</dict>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>pkg_path</key>
+					<string>%pathname%</string>
+					<key>repo_subdirectory</key>
+					<string>%MUNKI_REPO_SUBDIR%</string>
+				</dict>
+				<key>Processor</key>
+				<string>MunkiImporter</string>
+			</dict>
+		</array>
+	</dict>
+</plist>

--- a/Mozilla/ThunderbirdSignedPkg.pkg.recipe
+++ b/Mozilla/ThunderbirdSignedPkg.pkg.recipe
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Description</key>
+		<string>This recipe downloads the signed installer package that Mozilla made available starting in Thunderbird 69.0. Because the downloaded file is already a package, this pkg recipe does not add any further actions.
+
+The RELEASE key used in the standard Thunderbird recipes are not yet supported.
+LOCALE controls the language localization to be downloaded.
+Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
+See the following URL for possible LOCALE values:
+	http://ftp.mozilla.org/pub/thunderbird/releases/latest/README.txt
+</string>
+		<key>Identifier</key>
+		<string>com.github.autopkg.pkg.ThunderbirdSignedPkg</string>
+		<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>Thunderbird</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>2.0</string>
+		<key>ParentRecipe</key>
+		<string>com.github.autopkg.download.ThunderbirdSignedPkg</string>
+		<key>Process</key>
+		<array/>
+	</dict>
+</plist>


### PR DESCRIPTION
Mirrors the Firefox signed packages, but for Thunderbird instead.