### PR TITLE
Update flake8 URL in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v2.2.0
     hooks:
     -   id: seed-isort-config
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
     - id: flake8


### PR DESCRIPTION
The flake8 pre-commit hook URL has changed (see PyCQA/flake8#1737). This PR makes the needed adjustment to the pre-commit config.