### PR TITLE
Update GoogleChromePkg.munki.recipe

### DIFF
--- a/GoogleChrome/GoogleChromePkg.munki.recipe
+++ b/GoogleChrome/GoogleChromePkg.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 	<dict>
 		<key>Description</key>
-		<string>Downloads the latest version of the Google Chrome Enterprise Package and imports it into Munki.</string>
+		<string>Downloads the latest version of the Google Chrome Enterprise Package and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 		<key>Identifier</key>
 		<string>com.github.autopkg.munki.googlechromepkg</string>
 		<key>Input</key>
 		<dict>
+			<key>DERIVE_MIN_OS</key>
+			<string>YES</string>
 			<key>MUNKI_REPO_SUBDIR</key>
 			<string>apps/Google</string>
 			<key>NAME</key>
@@ -35,7 +39,7 @@
 			</dict>
 		</dict>
 		<key>MinimumVersion</key>
-		<string>1.4.1</string>
+		<string>2.7</string>
 		<key>ParentRecipe</key>
 		<string>com.github.autopkg.download.googlechromepkg</string>
 		<key>Process</key>
@@ -92,6 +96,8 @@
 					<array>
 						<string>/Applications/Google Chrome.app</string>
 					</array>
+					<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
 				</dict>
 				<key>Processor</key>
 				<string>MunkiInstallsItemsCreator</string>


### PR DESCRIPTION
Hi,

The GoogleChromePkg Munki recipe currently doesn't set the `min_os_version` from the App's info.plist, and as such the default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.13

This change requires AutoPkg version 2.7 or a higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/recipes/GoogleChrome/GoogleChromePkg.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/recipes/GoogleChrome/GoogleChromePkg.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/recipes/GoogleChrome/GoogleChromePkg.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 12 Dec 2022 23:05:42 GMT
URLDownloader: Storing new ETag header: "10c3da5"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.autopkg.munki.googlechromepkg/downloads/GoogleChrome.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "GoogleChrome.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-12-12 22:23:13 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Google LLC (EQHXZ8M8AV)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            40 02 6A 12 12 38 F4 E0 3F 7B CE 86 FA 5A 22 2B DA 7A 3A 20 70 FF 
CodeSignatureVerifier:            28 0D 86 AA 4E 02 56 C5 B2 B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.autopkg.munki.googlechromepkg/downloads/GoogleChrome.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.autopkg.munki.googlechromepkg/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.autopkg.munki.googlechromepkg/unpack/GoogleChrome.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.autopkg.munki.googlechromepkg/payload/Applications
Versioner
Versioner: Found version 108.0.5359.124 in file /Users/paul/Library/AutoPkg/Cache/com.github.autopkg.munki.googlechromepkg/payload/Applications/Google Chrome.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '108.0.5359.124'} into pkginfo
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Google Chrome.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.13
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '108.0.5359.124', 'installs': [{'CFBundleIdentifier': 'com.google.Chrome', 'CFBundleName': 'Chrome', 'CFBundleShortVersionString': '108.0.5359.124', 'CFBundleVersion': '5359.124', 'minosversion': '10.13', 'path': '/Applications/Google Chrome.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.13'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Google/GoogleChrome-108.0.5359.124.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Google/GoogleChrome-108.0.5359.124.pkg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.autopkg.munki.googlechromepkg/receipts/GoogleChromePkg.munki-receipt-20221220-140119.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    /Users/paul/Library/AutoPkg/Cache/com.github.autopkg.munki.googlechromepkg/downloads/GoogleChrome.pkg  

The following new items were imported into Munki:
    Name          Version         Catalogs  Pkginfo Path                                   Pkg Repo Path                                Icon Repo Path  
    ----          -------         --------  ------------                                   -------------                                --------------  
    GoogleChrome  108.0.5359.124  testing   apps/Google/GoogleChrome-108.0.5359.124.plist  apps/Google/GoogleChrome-108.0.5359.124.pkg
```