### PR TITLE
Update Sparkle feed URLs

### DIFF
--- a/XQuartz/XQuartz.download.recipe
+++ b/XQuartz/XQuartz.download.recipe
@@ -5,7 +5,7 @@
         <key>Description</key>
         <string>Download recipe for XQuartz. Downloads latest XQuartz disk image.
 
-Override BRANCH with either 'beta' or 'release' for the applicable Sparkle feed.
+Override BRANCH with either 'alpha', 'beta', or 'release' for the applicable Sparkle feed.
         </string>
         <key>Identifier</key>
         <string>com.github.autopkg.download.xquartz</string>
@@ -26,7 +26,7 @@ Override BRANCH with either 'beta' or 'release' for the applicable Sparkle feed.
                 <key>Arguments</key>
                 <dict>
                     <key>appcast_url</key>
-                    <string>https://www.xquartz.org/releases/sparkle/%BRANCH%.xml</string>
+                    <string>https://www.xquartz.org/releases/sparkle-r1/%BRANCH%.xml</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
Update Sparkle feed URLs for XQuartz.download.recipe from  https://www.xquartz.org/releases/sparkle/...
to
https://www.xquartz.org/releases/sparkle-r1/...

based on changes made to https://www.xquartz.org/. This change allows the recipe to pull the latest releases, whereas the old URLs stop at v2.8.2.