### PR TITLE
Correct path in XQuartz.munki.recipe for .pkg

### DIFF
--- a/XQuartz/XQuartz.munki.recipe
+++ b/XQuartz/XQuartz.munki.recipe
@@ -48,7 +48,7 @@ The XQuartz project is an open-source effort to develop a version of the X.Org X
             <key>Arguments</key>
             <dict>
                 <key>flat_pkg_path</key>
-                <string>%pathname%/XQuartz.pkg</string>
+                <string>%pathname%</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/unpack</string>
             </dict>


### PR DESCRIPTION
Previous XQuartz releases (up to 2.8.2) were __.dmg__; v2.8.3 and 2.8.4 have been .pkg, and FlatPkgUnpacker will fail to find the downloaded .pkg when the flat_pkg_path is %pathname%/XQuartz.pkg (since it does not exist; %pathname% itself is /some/path/to/cache/XQuartz-version.pkg).