### PR TITLE
Updated XQuartz.download.recipe fixed .pkg path

### DIFF
--- a/XQuartz/XQuartz.download.recipe
+++ b/XQuartz/XQuartz.download.recipe
@@ -53,7 +53,7 @@ Override BRANCH with either 'alpha', 'beta', or 'release' for the applicable Spa
                 <key>Arguments</key>
                 <dict>
                     <key>input_path</key>
-                    <string>%pathname%/XQuartz.pkg</string>
+                    <string>%pathname%</string>
                     <key>expected_authority_names</key>
                     <array>
                         <string>Developer ID Installer: Apple Inc. - XQuartz (NA574AWV7E)</string>


### PR DESCRIPTION
The path _also_ needed to be corrected in the CodeSignatureVerifier input_path string, from  %pathname%/XQuartz.pkg
to
%pathname%. Sorry for the extra effort - should've gone in with the first one.