### PR TITLE
Update munkitools6.munki.recipe

### DIFF
--- a/munkitools/munkitools6-signed.munki.recipe
+++ b/munkitools/munkitools6-signed.munki.recipe
@@ -3,12 +3,11 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads and imports the unsigned release of Munki tools version 6
-via the official releases listing on GitHub. You can set INCLUDE_PRERELEASES
-to any value to have this recipe pull prerelease versions.
+    <string>Downloads and imports the signed release of Munki tools version 6
+via the Mac Admins Open Source repo on GitHub.
 
-NOTE: Use the "com.github.autopkg.munki.munkitools6-signed" recipe to
-download the code signed version of the Munki tools via Mac Admins Open Source.
+NOTE: Use the "com.github.autopkg.munki.munkitools6" recipe to
+download the unsigned version of Munki via the official repo releases.
 
 Note that Munki 6 includes an optional component pkg, munkitools_app_usage.
 This recipe imports this to the Munki with the appropriate 'requires' key,
@@ -27,11 +26,9 @@ descending by tag names according to LooseVersion semantics.
 MUNKI_ICON should be overridden with your icon name.
 </string>
     <key>Identifier</key>
-    <string>com.github.autopkg.munki.munkitools6</string>
+    <string>com.github.autopkg.munki.munkitools6-signed</string>
     <key>Input</key>
     <dict>
-        <key>INCLUDE_PRERELEASES</key>
-        <string></string>
         <key>NAME</key>
         <string>munkitools6</string>
         <key>MUNKI_CATALOG</key>
@@ -99,9 +96,7 @@ MUNKI_ICON should be overridden with your icon name.
                 <key>asset_regex</key>
                 <string>^munkitools-6.*?pkg$</string>
                 <key>github_repo</key>
-                <string>munki/munki</string>
-                <key>include_prereleases</key>
-                <string>%INCLUDE_PRERELEASES%</string>
+                <string>macadmins/munki-builds</string>
             </dict>
         </dict>
         <dict>
@@ -111,6 +106,21 @@ MUNKI_ICON should be overridden with your icon name.
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>

--- a/munkitools/munkitools6.munki.recipe
+++ b/munkitools/munkitools6.munki.recipe
@@ -281,7 +281,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.11</string>
+                    <string>10.13</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_CORE_NAME%</string>
                     <key>requires</key>
@@ -320,7 +320,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.11</string>
+                    <string>10.13</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_ADMIN_NAME%</string>
                     <key>unattended_install</key>
@@ -359,7 +359,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.11</string>
+                    <string>10.13</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_APP_NAME%</string>
                     <key>requires</key>
@@ -399,7 +399,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.11</string>
+                    <string>10.13</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_APP_USAGE_NAME%</string>
                     <key>requires</key>
@@ -439,7 +439,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.11</string>
+                    <string>10.13</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
                 </dict>
@@ -471,7 +471,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <key>icon_name</key>
                     <string>%MUNKI_ICON%</string>
                     <key>minimum_os_version</key>
-                    <string>10.11</string>
+                    <string>10.13</string>
                     <key>name</key>
                     <string>%MUNKITOOLS_PYTHON_NAME%</string>
                     <key>unattended_install</key>

--- a/munkitools/munkitools6.munki.recipe
+++ b/munkitools/munkitools6.munki.recipe
@@ -9,8 +9,8 @@ official releases listing by default.
 To download the codesigned version of Munki change the "GITHUB_REPO" variable
 from the default of "munki/munki" to the alternative: macadmins/munki-builds
 
-If using "macadmins/munki-builds" you can also set "DISABLE_CODE_SIGNATURE_VERIFICATION"
-to an empty value to verify the signature on the downloaded package.
+If using "macadmins/munki-builds" you can also change "DISABLE_CODE_SIGNATURE_VERIFICATION"
+to "false" to verify the signature of the downloaded package.
 
 If using the default "munki/munki" repo, you can set INCLUDE_PRERELEASES to
 any value to have this recipe pull prerelease versions.
@@ -36,7 +36,7 @@ MUNKI_ICON should be overridden with your icon name.
         <key>GITHUB_REPO</key>
         <string>munki/munki</string>
         <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-        <string>yes</string>
+        <true/>
         <key>INCLUDE_PRERELEASES</key>
         <string></string>
         <key>NAME</key>

--- a/munkitools/munkitools6.munki.recipe
+++ b/munkitools/munkitools6.munki.recipe
@@ -3,13 +3,14 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Note: munkitools does not include a code signature. If your
-organization requires code signature, it is recommend to internally sign
-the application.
+    <string>Downloads and imports version 6 of the Munki tools via GitHub from the
+official releases listing by default.
 
-Downloads and imports version 6 of the Munki tools via
-the official releases listing on GitHub. You can set INCLUDE_PRERELEASES
-to any value to have this recipe pull prerelease versions.
+To download the codesigned version of Munki change the "GITHUB_REPO" variable
+from the default of "munki/munki" to the alternative: macadmins/munki-builds
+
+If using the default "munki/munki" repo, you can set INCLUDE_PRERELEASES to
+any value to have this recipe pull prerelease versions.
 
 Note that Munki 6 includes an optional component pkg, munkitools_app_usage.
 This recipe imports this to the Munki with the appropriate 'requires' key,
@@ -17,8 +18,6 @@ however as it is considered an optional component, this recipe does not
 add it as an update_for any Munki component. Admins should add
 munkitools_app_usage to a manifest manually if its installation on clients
 is desired.
-
-This recipe cannot be overridden to pull a download from an alternate location.
 
 The GitHubReleasesInfoProvider processor used by this recipe also
 respects an input variable: 'sort_by_highest_tag_names', which
@@ -31,6 +30,8 @@ MUNKI_ICON should be overridden with your icon name.
     <string>com.github.autopkg.munki.munkitools6</string>
     <key>Input</key>
     <dict>
+        <key>GITHUB_REPO</key>
+        <string>munki/munki</string>
         <key>INCLUDE_PRERELEASES</key>
         <string></string>
         <key>NAME</key>
@@ -100,7 +101,7 @@ MUNKI_ICON should be overridden with your icon name.
                 <key>asset_regex</key>
                 <string>^munkitools-6.*?pkg$</string>
                 <key>github_repo</key>
-                <string>munki/munki</string>
+                <string>%GITHUB_REPO%</string>
                 <key>include_prereleases</key>
                 <string>%INCLUDE_PRERELEASES%</string>
             </dict>

--- a/munkitools/munkitools6.munki.recipe
+++ b/munkitools/munkitools6.munki.recipe
@@ -9,6 +9,9 @@ official releases listing by default.
 To download the codesigned version of Munki change the "GITHUB_REPO" variable
 from the default of "munki/munki" to the alternative: macadmins/munki-builds
 
+If using "macadmins/munki-builds" you can also set "DISABLE_CODE_SIGNATURE_VERIFICATION"
+to an empty value to verify the signature on the downloaded package.
+
 If using the default "munki/munki" repo, you can set INCLUDE_PRERELEASES to
 any value to have this recipe pull prerelease versions.
 
@@ -32,6 +35,8 @@ MUNKI_ICON should be overridden with your icon name.
     <dict>
         <key>GITHUB_REPO</key>
         <string>munki/munki</string>
+        <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
+        <string>yes</string>
         <key>INCLUDE_PRERELEASES</key>
         <string></string>
         <key>NAME</key>
@@ -113,6 +118,21 @@ MUNKI_ICON should be overridden with your icon name.
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>
@@ -287,7 +307,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <string>%MUNKITOOLS_CORE_NAME%</string>
                     <key>requires</key>
                     <array>
-                    	<string>%MUNKITOOLS_PYTHON_NAME%</string>
+                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
                         <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
                     </array>
                     <key>unattended_install</key>
@@ -328,8 +348,8 @@ MUNKI_ICON should be overridden with your icon name.
                     <true/>
                     <key>update_for</key>
                     <array>
-                     	<string>%MUNKITOOLS_PYTHON_NAME%</string>
-                       <string>%MUNKITOOLS_CORE_NAME%</string>
+                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
+                        <string>%MUNKITOOLS_CORE_NAME%</string>
                     </array>
                 </dict>
             </dict>
@@ -365,7 +385,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <string>%MUNKITOOLS_APP_NAME%</string>
                     <key>requires</key>
                     <array>
-                    	<string>%MUNKITOOLS_PYTHON_NAME%</string>
+                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
                         <string>%MUNKITOOLS_CORE_NAME%</string>
                         <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
                     </array>
@@ -405,7 +425,7 @@ MUNKI_ICON should be overridden with your icon name.
                     <string>%MUNKITOOLS_APP_USAGE_NAME%</string>
                     <key>requires</key>
                     <array>
-                    	<string>%MUNKITOOLS_PYTHON_NAME%</string>
+                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
                         <string>%MUNKITOOLS_CORE_NAME%</string>
                         <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
                     </array>


### PR DESCRIPTION
Munki 6.3, released yesterday, changed the minimum supported version of macOS to 10.13.

https://github.com/munki/munki/releases/tag/v6.3.0

-vvv run log: [munkitools6.munki.recipe.log](https://github.com/autopkg/recipes/files/11275047/munkitools6.munki.recipe.log)
