### PR TITLE
Update dropbox recipe for supported_architectures

### DIFF
--- a/Dropbox/Dropbox.download.recipe
+++ b/Dropbox/Dropbox.download.recipe
@@ -3,13 +3,22 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Dropbox</string>
+    <string>Downloads the current release version of Dropbox
+
+ARCHITECTURE
+- x86_64 (default)
+- arm64
+</string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.dropbox</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Dropbox</string>
+        <key>ARCHITECTURE</key>
+        <string>x86_64</string>
+        <key>DOWNLOAD_URL</key>
+        <string>https://www.dropbox.com/download?plat=mac&amp;arch=%ARCHITECTURE%&amp;full=1</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -19,7 +28,7 @@
             <key>Arguments</key>
             <dict>
             	<key>url</key>
-            	<string>https://www.dropbox.com/download?plat=mac&amp;full=1</string>
+            	<string>%DOWNLOAD_URL%</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
             </dict>

--- a/Dropbox/Dropbox.munki.recipe
+++ b/Dropbox/Dropbox.munki.recipe
@@ -5,6 +5,8 @@
     <key>Description</key>
     <string>Downloads the current release version of Dropbox and imports into Munki.
 
+Use either x86_64 or arm64 for ARCHITECTURE key.
+
 Postinstall script extracts the DropboxHelperInstaller and sets the setuid
 bit so that it can perform its setup tasks as root without asking for admin
 privileges.
@@ -22,6 +24,8 @@ to quit Dropbox.</string>
     <string>com.github.autopkg.munki.dropbox</string>
     <key>Input</key>
     <dict>
+        <key>ARCHITECTURE</key>
+        <string>x86_64</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Dropbox</string>
         <key>NAME</key>
@@ -38,6 +42,10 @@ to quit Dropbox.</string>
             <string>Dropbox</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%ARCHITECTURE%</string>
+            </array>
             <key>postinstall_script</key>
             <string>#!/bin/sh
 # based on Ruby postinstall script by Riley Shott:


### PR DESCRIPTION
updated recipe to support arm64 dropbox download.

create an override and specify ARCHITECTURE to get arm vs intel.