### PR TITLE
Update Evernote.download.recipe

### DIFF
--- a/Evernote/Evernote.download.recipe
+++ b/Evernote/Evernote.download.recipe
@@ -15,6 +15,17 @@
     <string>0.4.0</string>
     <key>Process</key>
     <array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://evernote.com/download/</string>
+				<key>re_pattern</key>
+				<string>\.zip.*?(https://cdn1\.evernote\.com/boron/mac/builds/Evernote-.*?-mac-.*?\.dmg)\\n</string>
+			</dict>
+		</dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -23,7 +34,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://evernote.com/download/get.php?file=EvernoteMac</string>
+                <string>%match%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Adds URLTextSearcher step to scrape https://evernote.com/download/ for the download URL as appears that https://evernote.com/download/get.php?file=EvernoteMac is no longer a working link