### PR TITLE
Fix for #468 Evernote.download recipe

### DIFF
--- a/Evernote/Evernote.download.recipe
+++ b/Evernote/Evernote.download.recipe
@@ -15,6 +15,18 @@
     <string>0.4.0</string>
     <key>Process</key>
     <array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<!--<string>https://cdn1.evernote.com/boron/mac/builds/Evernote-.[A-Za-z0-9\-\.]\.dmg</string>-->
+				<string>https:\/\/cdn1\.evernote\.com\/boron\/mac\/builds\/Evernote-\d+\.\d+\.\d+-mac-ddl-stage-\d+-[a-fA-F0-9]+\.dmg</string>
+                <key>url</key>
+				<string>https://cdn1.evernote.com/boron/mac/public/latest-mac.yml</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -23,7 +35,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://evernote.com/download/get.php?file=EvernoteMac</string>
+                <string>%match%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The existing URL can no longer be parsed for the download link. This PR parses `https://cdn1.evernote.com/boron/mac/public/latest-mac.yml` instead, requiring a new URLTextSearcher step.