### PR TITLE
MSOffice: Handling of minimum_os_versions

### DIFF
--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -21,6 +21,7 @@ import plistlib
 import re
 
 from autopkglib import ProcessorError
+from autopkglib import version_equal_or_greater
 from autopkglib.URLGetter import URLGetter
 
 __all__ = ["MSOfficeMacURLandUpdateInfoProvider"]
@@ -111,7 +112,7 @@ PROD_DICT = {
     "Teams2": {
         "id": "TEAMS21",
         "path": "/Applications/Microsoft Teams (work or school).app",
-        "minimum_os": "10.15",
+        "minimum_os": "12.0",
     },
     "CompanyPortal": {
         "id": "IMCP01",
@@ -336,6 +337,16 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
             or PROD_DICT[self.env["product"]].get("minimum_os")
             or "10.10.5"
         )
+
+        # Make sure that the minimum_os_version is at least higher than the pre defined value
+        if not version_equal_or_greater(
+            pkginfo["minimum_os_version"],
+            PROD_DICT[self.env["product"]].get("minimum_os", "10.10.5")
+        ):
+            pkginfo["minimum_os_version"] = PROD_DICT[self.env["product"]].get(
+                "minimum_os",
+                "10.10.5"
+            )
 
         installs_items = self.get_installs_items(item)
         if installs_items:


### PR DESCRIPTION
For the new Microsoft Teams client Microsoft [documents](https://learn.microsoft.com/en-us/microsoftteams/new-teams-mac-install-prerequisites#prerequisites) a minimum_os_version of macOS 12, the [dynamically retrieved metadata](https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409TEAMS21.xml) currently lists `10.11.0` as requirement.

To handle problems of this kind I have modified the processor to respect any manually defined minimum_os_version even if MS provides a different, but lower value.