### PR TITLE
Dropbox download url parameter fix for unwanted beta builds

### DIFF
--- a/Dropbox/Dropbox.download.recipe
+++ b/Dropbox/Dropbox.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Dropbox</string>
+    <string>Downloads the current release version of Dropbox. Change the BUILD value from 'stable' to 'beta' for beta builds.</string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.dropbox</string>
     <key>Input</key>

--- a/Dropbox/Dropbox.download.recipe
+++ b/Dropbox/Dropbox.download.recipe
@@ -10,6 +10,10 @@
     <dict>
         <key>NAME</key>
         <string>Dropbox</string>
+        <key>DOWNLOADURL</key>
+        <string>https://www.dropbox.com/download?plat=mac&amp;full=1&amp;build=%BUILD%</string>
+        <key>BUILD</key>
+        <string>stable</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>

--- a/Dropbox/Dropbox.download.recipe
+++ b/Dropbox/Dropbox.download.recipe
@@ -22,8 +22,8 @@
         <dict>
             <key>Arguments</key>
             <dict>
-            	<key>url</key>
-            	<string>https://www.dropbox.com/download?plat=mac&amp;full=1</string>
+                <key>url</key>
+                <string>%DOWNLOADURL%</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
             </dict>


### PR DESCRIPTION
Ref this issue: https://github.com/autopkg/recipes/issues/473

- Changes from using a download URL that is hardcoded in the process section to using input variables that can be overridden as desired
  - Allows overriding the both the build type (stable vs beta, possibly others?) parameter 
  - Allows overriding the download URL value wholesale
- Adds a parameter to the download URL for the build type explicitly, which seems to always provide the requested build vs the current behavior that randomly gives you a beta build instead of a stable.