### PR TITLE
Update munkitools6 recipes

### DIFF
--- a/munkitools/munkitools6-signed.munki.recipe
+++ b/munkitools/munkitools6-signed.munki.recipe
@@ -10,21 +10,12 @@ to any value to have this recipe pull prerelease versions.
 NOTE: Use the "com.github.autopkg.munki.munkitools6" recipe to
 download the unsigned version of Munki via the official repo releases.
 
-Note that Munki 6 includes an optional component pkg, munkitools_app_usage.
-This recipe imports this to the Munki with the appropriate 'requires' key,
-however as it is considered an optional component, this recipe does not
-add it as an update_for any Munki component. Admins should add
-munkitools_app_usage to a manifest manually if its installation on clients
-is desired.
-
 This recipe cannot be overridden to pull a download from an alternate location.
 
 The GitHubReleasesInfoProvider processor used by this recipe also
 respects an input variable: 'sort_by_highest_tag_names', which
 if set, will ignore the post dates of the releases and instead sort
 descending by tag names according to LooseVersion semantics.
-
-MUNKI_ICON should be overridden with your icon name.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.munkitools6-signed</string>
@@ -33,59 +24,32 @@ MUNKI_ICON should be overridden with your icon name.
         <key>INCLUDE_PRERELEASES</key>
         <string></string>
         <key>NAME</key>
-        <string>munkitools6</string>
-        <key>MUNKI_CATALOG</key>
-        <string>development</string>
-        <key>MUNKI_CATEGORY</key>
         <string>munkitools</string>
-        <key>MUNKI_DEVELOPER</key>
-        <string>The Munki Project</string>
-        <key>MUNKI_ICON</key>
-        <string></string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>munkitools</string>
-        <!--  -->
-        <key>MUNKITOOLS_CORE_NAME</key>
-        <string>munkitools_core</string>
-        <key>MUNKITOOLS_CORE_DISPLAYNAME</key>
-        <string>Managed Software Center core tools</string>
-        <key>MUNKITOOLS_CORE_DESCRIPTION</key>
-        <string>Core command-line tools used by Managed Software Center.</string>
-        <!--  -->
-        <key>MUNKITOOLS_ADMIN_NAME</key>
-        <string>munkitools_admin</string>
-        <key>MUNKITOOLS_ADMIN_DISPLAYNAME</key>
-        <string>Managed Software Center admin tools</string>
-        <key>MUNKITOOLS_ADMIN_DESCRIPTION</key>
-        <string>Command-line Managed Software Center admin tools.</string>
-        <!--  -->
-        <key>MUNKITOOLS_APP_NAME</key>
-        <string>munkitools</string>
-        <key>MUNKITOOLS_APP_DISPLAYNAME</key>
-        <string>Managed Software Center</string>
-        <key>MUNKITOOLS_APP_DESCRIPTION</key>
-        <string>Managed Software Center application.</string>
-        <!--  -->
-        <key>MUNKITOOLS_APP_USAGE_NAME</key>
-        <string>munkitools_app_usage</string>
-        <key>MUNKITOOLS_APP_USAGE_DISPLAYNAME</key>
-        <string>Managed Software Center app usage</string>
-        <key>MUNKITOOLS_APP_USAGE_DESCRIPTION</key>
-        <string>Application usage statistics for Managed Software Center.</string>
-        <!--  -->
-        <key>MUNKITOOLS_LAUNCHD_NAME</key>
-        <string>munkitools_launchd</string>
-        <key>MUNKITOOLS_LAUNCHD_DISPLAYNAME</key>
-        <string>Managed Software Center launchd files</string>
-        <key>MUNKITOOLS_LAUNCHD_DESCRIPTION</key>
-        <string>launchd configuration files for use by Managed Software Center.</string>
-        <!--  -->
-        <key>MUNKITOOLS_PYTHON_NAME</key>
-        <string>munkitools_python</string>
-        <key>MUNKITOOLS_PYTHON_DISPLAYNAME</key>
-        <string>Managed Software Center embedded python</string>
-        <key>MUNKITOOLS_PYTHON_DESCRIPTION</key>
-        <string>Embedded Python tools used by Managed Software Center.</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>development</string>
+            </array>
+            <key>category</key>
+            <string>munkitools</string>
+            <key>description</key>
+            <string>Managed software installation for macOS.</string>
+            <key>developer</key>
+            <string>The Munki Project</string>
+            <key>display_name</key>
+            <string>Managed Software Center</string>
+            <key>icon_name</key>
+            <string>Managed Software Center.png</string>
+            <key>minimum_os_version</key>
+            <string>10.13</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.5.0</string>
@@ -129,368 +93,25 @@ MUNKI_ICON should be overridden with your icon name.
         </dict>
         <dict>
             <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
+            <string>MunkiPkginfoMerger</string>
             <key>Arguments</key>
             <dict>
-                <key>flat_pkg_path</key>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
                 <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/repack</string>
-                <key>pkgdirs</key>
-                <dict/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_core*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_core.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_admin*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_admin.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_app[.-]*pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_app_usage*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app_usage.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_launchd*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_launchd.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_python*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_python.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_core.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_CORE_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_CORE_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_CORE_NAME%</string>
-                    <key>requires</key>
-                    <array>
-                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                        <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
-                    </array>
-                    <key>unattended_install</key>
-                    <true/>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_admin.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_ADMIN_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_ADMIN_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_ADMIN_NAME%</string>
-                    <key>unattended_install</key>
-                    <true/>
-                    <key>update_for</key>
-                    <array>
-                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                        <string>%MUNKITOOLS_CORE_NAME%</string>
-                    </array>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_APP_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_APP_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_APP_NAME%</string>
-                    <key>requires</key>
-                    <array>
-                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                        <string>%MUNKITOOLS_CORE_NAME%</string>
-                        <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
-                    </array>
-                    <key>unattended_install</key>
-                    <true/>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app_usage.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_APP_USAGE_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_APP_USAGE_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_APP_USAGE_NAME%</string>
-                    <key>requires</key>
-                    <array>
-                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                        <string>%MUNKITOOLS_CORE_NAME%</string>
-                        <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
-                    </array>
-                    <key>unattended_install</key>
-                    <true/>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_launchd.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_LAUNCHD_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_LAUNCHD_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_python.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_PYTHON_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_PYTHON_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                    <key>unattended_install</key>
-                    <true/>
-                </dict>
             </dict>
         </dict>
     </array>

--- a/munkitools/munkitools6.munki.recipe
+++ b/munkitools/munkitools6.munki.recipe
@@ -10,21 +10,12 @@ to any value to have this recipe pull prerelease versions.
 NOTE: Use the "com.github.autopkg.munki.munkitools6-signed" recipe to
 download the code signed version of the Munki tools via Mac Admins Open Source.
 
-Note that Munki 6 includes an optional component pkg, munkitools_app_usage.
-This recipe imports this to the Munki with the appropriate 'requires' key,
-however as it is considered an optional component, this recipe does not
-add it as an update_for any Munki component. Admins should add
-munkitools_app_usage to a manifest manually if its installation on clients
-is desired.
-
 This recipe cannot be overridden to pull a download from an alternate location.
 
 The GitHubReleasesInfoProvider processor used by this recipe also
 respects an input variable: 'sort_by_highest_tag_names', which
 if set, will ignore the post dates of the releases and instead sort
 descending by tag names according to LooseVersion semantics.
-
-MUNKI_ICON should be overridden with your icon name.
 </string>
     <key>Identifier</key>
     <string>com.github.autopkg.munki.munkitools6</string>
@@ -33,59 +24,32 @@ MUNKI_ICON should be overridden with your icon name.
         <key>INCLUDE_PRERELEASES</key>
         <string></string>
         <key>NAME</key>
-        <string>munkitools6</string>
-        <key>MUNKI_CATALOG</key>
-        <string>development</string>
-        <key>MUNKI_CATEGORY</key>
         <string>munkitools</string>
-        <key>MUNKI_DEVELOPER</key>
-        <string>The Munki Project</string>
-        <key>MUNKI_ICON</key>
-        <string></string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>munkitools</string>
-        <!--  -->
-        <key>MUNKITOOLS_CORE_NAME</key>
-        <string>munkitools_core</string>
-        <key>MUNKITOOLS_CORE_DISPLAYNAME</key>
-        <string>Managed Software Center core tools</string>
-        <key>MUNKITOOLS_CORE_DESCRIPTION</key>
-        <string>Core command-line tools used by Managed Software Center.</string>
-        <!--  -->
-        <key>MUNKITOOLS_ADMIN_NAME</key>
-        <string>munkitools_admin</string>
-        <key>MUNKITOOLS_ADMIN_DISPLAYNAME</key>
-        <string>Managed Software Center admin tools</string>
-        <key>MUNKITOOLS_ADMIN_DESCRIPTION</key>
-        <string>Command-line Managed Software Center admin tools.</string>
-        <!--  -->
-        <key>MUNKITOOLS_APP_NAME</key>
-        <string>munkitools</string>
-        <key>MUNKITOOLS_APP_DISPLAYNAME</key>
-        <string>Managed Software Center</string>
-        <key>MUNKITOOLS_APP_DESCRIPTION</key>
-        <string>Managed Software Center application.</string>
-        <!--  -->
-        <key>MUNKITOOLS_APP_USAGE_NAME</key>
-        <string>munkitools_app_usage</string>
-        <key>MUNKITOOLS_APP_USAGE_DISPLAYNAME</key>
-        <string>Managed Software Center app usage</string>
-        <key>MUNKITOOLS_APP_USAGE_DESCRIPTION</key>
-        <string>Application usage statistics for Managed Software Center.</string>
-        <!--  -->
-        <key>MUNKITOOLS_LAUNCHD_NAME</key>
-        <string>munkitools_launchd</string>
-        <key>MUNKITOOLS_LAUNCHD_DISPLAYNAME</key>
-        <string>Managed Software Center launchd files</string>
-        <key>MUNKITOOLS_LAUNCHD_DESCRIPTION</key>
-        <string>launchd configuration files for use by Managed Software Center.</string>
-        <!--  -->
-        <key>MUNKITOOLS_PYTHON_NAME</key>
-        <string>munkitools_python</string>
-        <key>MUNKITOOLS_PYTHON_DISPLAYNAME</key>
-        <string>Managed Software Center embedded python</string>
-        <key>MUNKITOOLS_PYTHON_DESCRIPTION</key>
-        <string>Embedded Python tools used by Managed Software Center.</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>development</string>
+            </array>
+            <key>category</key>
+            <string>munkitools</string>
+            <key>description</key>
+            <string>Managed software installation for macOS.</string>
+            <key>developer</key>
+            <string>The Munki Project</string>
+            <key>display_name</key>
+            <string>Managed Software Center</string>
+            <key>icon_name</key>
+            <string>Managed Software Center.png</string>
+            <key>minimum_os_version</key>
+            <string>10.13</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.5.0</string>
@@ -107,6 +71,11 @@ MUNKI_ICON should be overridden with your icon name.
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.pkg</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>
@@ -114,368 +83,25 @@ MUNKI_ICON should be overridden with your icon name.
         </dict>
         <dict>
             <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
+            <string>MunkiPkginfoMerger</string>
             <key>Arguments</key>
             <dict>
-                <key>flat_pkg_path</key>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
                 <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/repack</string>
-                <key>pkgdirs</key>
-                <dict/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_core*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_core.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_admin*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_admin.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_app[.-]*pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_app_usage*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app_usage.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_launchd*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_launchd.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/munkitools_python*.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgPacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_flatpkg_dir</key>
-                <string>%found_filename%</string>
-                <key>destination_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_python.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_core.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_CORE_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_CORE_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_CORE_NAME%</string>
-                    <key>requires</key>
-                    <array>
-                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                        <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
-                    </array>
-                    <key>unattended_install</key>
-                    <true/>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_admin.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_ADMIN_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_ADMIN_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_ADMIN_NAME%</string>
-                    <key>unattended_install</key>
-                    <true/>
-                    <key>update_for</key>
-                    <array>
-                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                        <string>%MUNKITOOLS_CORE_NAME%</string>
-                    </array>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_APP_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_APP_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_APP_NAME%</string>
-                    <key>requires</key>
-                    <array>
-                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                        <string>%MUNKITOOLS_CORE_NAME%</string>
-                        <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
-                    </array>
-                    <key>unattended_install</key>
-                    <true/>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_app_usage.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_APP_USAGE_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_APP_USAGE_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_APP_USAGE_NAME%</string>
-                    <key>requires</key>
-                    <array>
-                        <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                        <string>%MUNKITOOLS_CORE_NAME%</string>
-                        <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
-                    </array>
-                    <key>unattended_install</key>
-                    <true/>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_launchd.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_LAUNCHD_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_LAUNCHD_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_LAUNCHD_NAME%</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/repack/munkitools_python.pkg</string>
-                <key>pkginfo</key>
-                <dict>
-                    <key>catalogs</key>
-                    <array>
-                        <string>%MUNKI_CATALOG%</string>
-                    </array>
-                    <key>category</key>
-                    <string>%MUNKI_CATEGORY%</string>
-                    <key>description</key>
-                    <string>%MUNKITOOLS_PYTHON_DESCRIPTION%</string>
-                    <key>developer</key>
-                    <string>%MUNKI_DEVELOPER%</string>
-                    <key>display_name</key>
-                    <string>%MUNKITOOLS_PYTHON_DISPLAYNAME%</string>
-                    <key>icon_name</key>
-                    <string>%MUNKI_ICON%</string>
-                    <key>minimum_os_version</key>
-                    <string>10.13</string>
-                    <key>name</key>
-                    <string>%MUNKITOOLS_PYTHON_NAME%</string>
-                    <key>unattended_install</key>
-                    <true/>
-                </dict>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
This updates both variants of the munkitools6 recipes to no longer decompose the package as discussed on the `munki-discuss` mailing list.

`-vv` runs attached.

[munkitools6.txt](https://github.com/user-attachments/files/16840931/munkitools6.txt)
[munkitools6-signed.txt](https://github.com/user-attachments/files/16840932/munkitools6-signed.txt)
