### PR TITLE
Added input variable for MUNKI_ICON

### DIFF
--- a/munkitools/munkitools6-signed.munki.recipe
+++ b/munkitools/munkitools6-signed.munki.recipe
@@ -27,6 +27,8 @@ descending by tag names according to LooseVersion semantics.
         <string>munkitools</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>munkitools</string>
+        <key>MUNKI_ICON</key>
+        <string>Managed Software Center.png</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -42,7 +44,7 @@ descending by tag names according to LooseVersion semantics.
             <key>display_name</key>
             <string>Managed Software Center</string>
             <key>icon_name</key>
-            <string>Managed Software Center.png</string>
+            <string>%MUNKI_ICON%</string>
             <key>minimum_os_version</key>
             <string>10.13</string>
             <key>name</key>

--- a/munkitools/munkitools6.munki.recipe
+++ b/munkitools/munkitools6.munki.recipe
@@ -27,6 +27,8 @@ descending by tag names according to LooseVersion semantics.
         <string>munkitools</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>munkitools</string>
+        <key>MUNKI_ICON</key>
+        <string>Managed Software Center.png</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -42,7 +44,7 @@ descending by tag names according to LooseVersion semantics.
             <key>display_name</key>
             <string>Managed Software Center</string>
             <key>icon_name</key>
-            <string>Managed Software Center.png</string>
+            <string>%MUNKI_ICON%</string>
             <key>minimum_os_version</key>
             <string>10.13</string>
             <key>name</key>


### PR DESCRIPTION
Is it possible not to hardcode the value for `icon_name` inside of the `pkginfo` input variable?

If you were using the older recipe in it's default state then the icon for munkitools was set to a variable called `%MUNKI_ICON%` and if (like me) you had this set to anything other than "Managed Software Center.png" this item no longer has an icon correctly allocated when using this recipe. I know it's relatively simple to just create a new icon in Munki for "Managed Software Centre.png" but this could easily be resolved if `icon_name` was changed to `%MUNKI_ICON%` inside the `pkginfo` and a corresponding input variable added.

Either this or most munki recipes don't specify the icon at all and it just defaults to the name of the munki item. I'm happy with either option but this PR implements the one above to be more backwards compatible with the old recipe and allows me to easily keep `MUNKI_ICON` set to "munkitools.png" without overriding the entire `pkginfo`.