### PR TITLE
added "esr-latest" as a suggested value for RELEASE

### DIFF
--- a/Mozilla/Thunderbird.download.recipe
+++ b/Mozilla/Thunderbird.download.recipe
@@ -4,7 +4,7 @@
 <dict>
     <key>Description</key>
     <string>Downloads Thunderbird disk image.
-Some useful values for RELEASE are: 'latest', 'beta-latest'.
+Some useful values for RELEASE are: 'latest', 'esr-latest', 'beta-latest'.
 LOCALE controls the language localization to be downloaded.
 Examples include 'en-US', 'de', 'sv-SE', and 'zh-TW'
 See the following URLs for more info:


### PR DESCRIPTION
Sometime between July 31 and now, the LATEST_THUNDERBIRD_VERSION in "https://product-details.mozilla.org/1.0/thunderbird_versions.json went from an esr version to a monthly build. The currently listed LATEST_THUNDERBIRD_VERSION is 131.0, but the app itself shows a message "This is an unsupported version of Thunderbird!" in several places in the GUI.

Presumably, most people will want the ESR version, so I added "esr-latest" as a suggested value for RELEASE in this recipe.

https://product-details.mozilla.org/1.0/thunderbird_versions.json from July 31 includes these lines:
```
    "LATEST_THUNDERBIRD_VERSION": "115.13.0",
    "THUNDERBIRD_ESR": "115.13.0",
```

September 6
``` 
    "LATEST_THUNDERBIRD_VERSION": "128.2.0esr",
    "THUNDERBIRD_ESR": "115.15.0",
```

October 3
```
    "LATEST_THUNDERBIRD_VERSION": "131.0",
    "THUNDERBIRD_ESR": "128.3.0esr",
```