### PR TITLE
Deprecate Coda recipes

### DIFF
--- a/Panic/Coda2.download.recipe
+++ b/Panic/Coda2.download.recipe
@@ -12,9 +12,18 @@
         <string>Coda2</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Panic has discontinued Coda in favor of Nova (details: https://panic.com/coda/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
This PR deprecates Coda recipes, because Panic has discontinued Coda in favor of Nova ([details](https://panic.com/coda/)).
