### PR TITLE
Deprecate TextMate (1) recipes

### DIFF
--- a/TextMate/TextMate.download.recipe
+++ b/TextMate/TextMate.download.recipe
@@ -13,9 +13,18 @@ is hardcoded because it's not likely to ever get another update.</string>
         <string>TextMate</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to this repo's TextMate2 recipes. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
As the description states, it's unlikely that TextMate 1 will get any further updates. This recipe is deprecated and will be removed.