### PR TITLE
Pre-commit update and associated changes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = autopkglib,past
+known_third_party = autopkglib,distutils

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,25 @@
 repos:
--   repo: https://github.com/python/black
-    rev: 20.8b1
+  - repo: https://github.com/homebysix/pre-commit-macadmin
+    rev: v1.18.0
     hooks:
-    - id: black
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.6.4
+      - id: check-autopkg-recipes
+        args: ["--recipe-prefix=com.github.autopkg.", "--strict", "--"]
+      - id: forbid-autopkg-overrides
+        exclude: ^(MSOfficeUpdates|OmniGroup)/
+      - id: forbid-autopkg-trust-info
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
     hooks:
-    - id: isort
--   repo: https://github.com/asottile/seed-isort-config
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/asottile/seed-isort-config
     rev: v2.2.0
     hooks:
-    -   id: seed-isort-config
--   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+      - id: seed-isort-config
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
     hooks:
-    - id: flake8
+      - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: check-autopkg-recipes
         args: ["--recipe-prefix=com.github.autopkg.", "--strict", "--"]
+        exclude: ^(MSOfficeUpdates|OmniGroup|munkitools|AutoPkg|Munki|Mozilla|SassafrasK2Client)/
       - id: forbid-autopkg-overrides
         exclude: ^(MSOfficeUpdates|OmniGroup)/
       - id: forbid-autopkg-trust-info

--- a/Adium/Adium.download.recipe
+++ b/Adium/Adium.download.recipe
@@ -14,7 +14,7 @@
         <string>release</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Adium/Adium.install.recipe
+++ b/Adium/Adium.install.recipe
@@ -12,7 +12,7 @@
         <string>Adium</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>0.4.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.Adium</string>
     <key>Process</key>

--- a/Adium/Adium.pkg.recipe
+++ b/Adium/Adium.pkg.recipe
@@ -46,9 +46,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Adium.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Adium.app</string>
             </dict>
         </dict>
         <dict>

--- a/AdobeAcrobatPro/AdobeAcrobatPro9Update.munki.recipe
+++ b/AdobeAcrobatPro/AdobeAcrobatPro9Update.munki.recipe
@@ -48,7 +48,7 @@ default, 'latest'.</string>
             </dict>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.2.0</string>
+        <string>1.1</string>
         <key>ParentRecipe</key>
         <string>com.github.autopkg.download.AdobeAcrobatPro9Update</string>
         <key>Process</key>

--- a/AdobeAcrobatPro/AdobeAcrobatProUpdateInfoProvider.py
+++ b/AdobeAcrobatPro/AdobeAcrobatProUpdateInfoProvider.py
@@ -125,9 +125,7 @@ class AdobeAcrobatProUpdateInfoProvider(URLGetter):
             # /{MAJREV}/get_version/{PROD}_{PROD_ARCH}.plist
             template_response = re.sub(r"\d+\.\d+\.\d+", get_version, template_response)
 
-        manifest_url = self.process_url_vars(
-            META_BASE_URL + template_response
-        )
+        manifest_url = self.process_url_vars(META_BASE_URL + template_response)
         manifest_data = self.get_manifest_data(manifest_url)
 
         composed_dl_url = DL_BASE_URL + manifest_data["PatchURL"]

--- a/AdobeReader/AdobeReader.pkg.recipe
+++ b/AdobeReader/AdobeReader.pkg.recipe
@@ -82,6 +82,17 @@ and enabling installation on non-boot volumes.</string>
 				</array>
 			</dict>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>source_pkg</key>
+				<string>%pkg_path%</string>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/AdobeReader/AdobeReaderDC.install.recipe
+++ b/AdobeReader/AdobeReaderDC.install.recipe
@@ -16,7 +16,7 @@
 		<string>AdobeReader</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.pkg.AdobeReaderDC</string>
 	<key>Process</key>

--- a/AdobeReader/AdobeReaderDC.pkg.recipe
+++ b/AdobeReader/AdobeReaderDC.pkg.recipe
@@ -17,7 +17,7 @@ and enabling installation on non-boot volumes.</string>
 		<string>AdobeReaderDC</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.AdobeReaderDC</string>
 	<key>Process</key>

--- a/AutoPkg/AutoPkg-Release.download.recipe
+++ b/AutoPkg/AutoPkg-Release.download.recipe
@@ -14,7 +14,7 @@
         <string></string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/AutoPkg/GenerateRelocatablePython.py
+++ b/AutoPkg/GenerateRelocatablePython.py
@@ -42,7 +42,7 @@ class GenerateRelocatablePython(Processor):
         "os_version": {
             "required": True,
             "description": "What OS to fetch.",
-        }
+        },
     }
     output_variables = {
         "python_path": {"description": "Path to built Python framework."}

--- a/Barebones/BarebonesURLProvider.py
+++ b/Barebones/BarebonesURLProvider.py
@@ -15,11 +15,11 @@
 # limitations under the License.
 """See docstring for BarebonesURLProvider class"""
 
-from distutils.version import LooseVersion
 import plistlib
 
 from autopkglib import ProcessorError
 from autopkglib.URLGetter import URLGetter
+from distutils.version import LooseVersion
 
 __all__ = ["BarebonesURLProvider"]
 

--- a/GoogleChrome/GoogleChrome.download.recipe
+++ b/GoogleChrome/GoogleChrome.download.recipe
@@ -14,7 +14,7 @@
         <string>https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/GoogleEarth/GoogleEarth.download.recipe
+++ b/GoogleEarth/GoogleEarth.download.recipe
@@ -14,7 +14,7 @@
         <string>https://dl.google.com/dl/earth/client/advanced/current/googleearthpromac-intel.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/GoogleEarth/GoogleEarth.munki.recipe
+++ b/GoogleEarth/GoogleEarth.munki.recipe
@@ -34,8 +34,9 @@
 	<string>com.github.autopkg.download.google-earth</string>
     <key>Process</key>
 	<array>
-        <!-- Make a fake pkg root -->
         <dict>
+            <key>Comment</key>
+            <string>Make a fake pkg root</string>
             <key>Arguments</key>
             <dict>
                 <key>pkgroot</key>
@@ -53,8 +54,9 @@
             <key>Processor</key>
             <string>PkgRootCreator</string>
         </dict>
-        <!-- Expand packages into fake root -->
         <dict>
+            <key>Comment</key>
+            <string>Expand packages into fake root</string>
             <key>Processor</key>
             <string>FlatPkgUnpacker</string>
             <key>Arguments</key>
@@ -76,8 +78,9 @@
                 <string>%RECIPE_CACHE_DIR%/expanded/Google_Earth_Pro.pkg/Payload</string>
             </dict>
         </dict>
-        <!-- Make and merge Munki installs items -->
         <dict>
+            <key>Comment</key>
+            <string>Make and merge Munki installs items</string>
             <key>Arguments</key>
             <dict>
                 <key>installs_item_paths</key>
@@ -96,8 +99,9 @@
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>
-        <!-- Extract a version from Google Earth.app and merge pkginfo version key -->
         <dict>
+            <key>Comment</key>
+            <string>Extract a version from Google Earth.app and merge pkginfo version key</string>
             <key>Processor</key>
             <string>Versioner</string>
             <key>Arguments</key>

--- a/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
+++ b/MSOffice2011Updates/MSOffice2011UpdateInfoProvider.py
@@ -17,11 +17,11 @@
 
 import plistlib
 from builtins import hex
-from distutils.version import LooseVersion
 from urllib.parse import urlparse, urlunparse
 
 from autopkglib import ProcessorError
 from autopkglib.URLGetter import URLGetter
+from distutils.version import LooseVersion
 
 __all__ = ["MSOffice2011UpdateInfoProvider"]
 

--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -20,8 +20,7 @@
 import plistlib
 import re
 
-from autopkglib import ProcessorError
-from autopkglib import version_equal_or_greater
+from autopkglib import ProcessorError, version_equal_or_greater
 from autopkglib.URLGetter import URLGetter
 
 __all__ = ["MSOfficeMacURLandUpdateInfoProvider"]
@@ -238,7 +237,7 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
     def get_installs_items(self, item):
         """Attempts to parse the Triggers to create an installs item using
         only manifest data, making the assumption that CFBundleVersion and
-        CFBundleShortVersionString are equal. Skip SkypeForBusiness, Teams, 
+        CFBundleShortVersionString are equal. Skip SkypeForBusiness, Teams,
         and Edge as their xml does not contain a 'Trigger Condition'"""
         if self.env["product"] not in NO_TRIGGER_CONDITIONS:
             self.sanity_check_expected_triggers(item)
@@ -351,11 +350,10 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
         # Make sure that the minimum_os_version is at least higher than the pre defined value
         if not version_equal_or_greater(
             pkginfo["minimum_os_version"],
-            PROD_DICT[self.env["product"]].get("minimum_os", "10.10.5")
+            PROD_DICT[self.env["product"]].get("minimum_os", "10.10.5"),
         ):
             pkginfo["minimum_os_version"] = PROD_DICT[self.env["product"]].get(
-                "minimum_os",
-                "10.10.5"
+                "minimum_os", "10.10.5"
             )
 
         installs_items = self.get_installs_items(item)
@@ -365,10 +363,10 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
         # If bundle_id is defined
         if PROD_DICT[self.env["product"]].get("bundle_id"):
             # Add to pkginfo
-            pkginfo["installs"][0]["CFBundleIdentifier"] = PROD_DICT[self.env["product"]].get(
-                "bundle_id"
-            )
-           
+            pkginfo["installs"][0]["CFBundleIdentifier"] = PROD_DICT[
+                self.env["product"]
+            ].get("bundle_id")
+
         # Extra work to do if this is a delta updater
         if self.env["version"] == "latest-delta":
             try:

--- a/Mozilla/FirefoxWindows.download.recipe
+++ b/Mozilla/FirefoxWindows.download.recipe
@@ -19,7 +19,7 @@
 			<string>msi-latest</string>
 		</dict>
 		<key>MinimumVersion</key>
-		<string>2.0</string>
+		<string>2.3</string>
 		<key>SupportedPlatforms</key>
 		<array>
 			<string>Windows</string>

--- a/OmniGroup/OmniGraffle6.download.recipe
+++ b/OmniGroup/OmniGraffle6.download.recipe
@@ -12,7 +12,7 @@
         <string>OmniGraffle6</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.omnigroupproduct</string>
     <key>Process</key>

--- a/OmniGroup/OmniGraffle7.download.recipe
+++ b/OmniGroup/OmniGraffle7.download.recipe
@@ -12,7 +12,7 @@
         <string>OmniGraffle7</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.omnigroupproduct</string>
     <key>Process</key>

--- a/OmniGroup/OmniOutliner4.download.recipe
+++ b/OmniGroup/OmniOutliner4.download.recipe
@@ -12,7 +12,7 @@
         <string>OmniOutliner4</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.omnigroupproduct</string>
     <key>Process</key>

--- a/OmniGroup/OmniOutliner5.download.recipe
+++ b/OmniGroup/OmniOutliner5.download.recipe
@@ -12,7 +12,7 @@
         <string>OmniOutliner5</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.omnigroupproduct</string>
     <key>Process</key>

--- a/OmniGroup/OmniPlan3.download.recipe
+++ b/OmniGroup/OmniPlan3.download.recipe
@@ -12,7 +12,7 @@
         <string>OmniPlan3</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.omnigroupproduct</string>
     <key>Process</key>

--- a/OracleJava/OracleJava8.download.recipe
+++ b/OracleJava/OracleJava8.download.recipe
@@ -20,7 +20,7 @@ http://www.oracle.com/technetwork/java/javase/terms/license/index.html
 		<string>OracleJava8</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/OracleJava/OracleJava8.munki.recipe
+++ b/OracleJava/OracleJava8.munki.recipe
@@ -53,7 +53,7 @@ the prefPane bundle, which has historically had consistent versioning.
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.OracleJava8</string>
 	<key>Process</key>

--- a/OracleJava/OracleJava8.pkg.recipe
+++ b/OracleJava/OracleJava8.pkg.recipe
@@ -24,7 +24,7 @@ http://www.oracle.com/technetwork/java/javase/terms/license/index.html
 		<string>com.oracle.jre</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.OracleJava8</string>
 	<key>Process</key>

--- a/Panic/Coda2.pkg.recipe
+++ b/Panic/Coda2.pkg.recipe
@@ -12,7 +12,7 @@
         <string>Coda2</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.5</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.coda2</string>
     <key>Process</key>

--- a/Panic/Transmit.pkg.recipe
+++ b/Panic/Transmit.pkg.recipe
@@ -12,7 +12,7 @@
         <string>Transmit</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.5</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.transmit</string>
     <key>Process</key>

--- a/Panic/Transmit5.pkg.recipe
+++ b/Panic/Transmit5.pkg.recipe
@@ -12,7 +12,7 @@
         <string>Transmit5</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.5</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.transmit5</string>
     <key>Process</key>

--- a/Praat/Praat.pkg.recipe
+++ b/Praat/Praat.pkg.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict/>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.Praat</string>
 	<key>Process</key>

--- a/Puppetlabs/PuppetlabsProductsURLProvider.py
+++ b/Puppetlabs/PuppetlabsProductsURLProvider.py
@@ -17,10 +17,10 @@
 
 import re
 from builtins import str
-from distutils.version import LooseVersion
 
 from autopkglib import ProcessorError
 from autopkglib.URLGetter import URLGetter
+from distutils.version import LooseVersion
 
 __all__ = ["PuppetlabsProductsURLProvider"]
 

--- a/SassafrasK2Client/SassafrasK2Client.munki.recipe
+++ b/SassafrasK2Client/SassafrasK2Client.munki.recipe
@@ -93,6 +93,10 @@ we use its version in the pkginfo.
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>base_pkg_path</key>

--- a/Silverlight/Silverlight.download.recipe
+++ b/Silverlight/Silverlight.download.recipe
@@ -16,7 +16,7 @@
             <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.6.0</string>
+        <string>1.1</string>
         <key>Process</key>
         <array>
             <dict>

--- a/Silverlight/Silverlight.install.recipe
+++ b/Silverlight/Silverlight.install.recipe
@@ -9,7 +9,7 @@
         <key>Input</key>
         <dict/>
         <key>MinimumVersion</key>
-        <string>0.6.0</string>
+        <string>1.1</string>
         <key>ParentRecipe</key>
         <string>com.github.autopkg.download.Silverlight</string>
         <key>Process</key>

--- a/Silverlight/Silverlight.munki.recipe
+++ b/Silverlight/Silverlight.munki.recipe
@@ -29,7 +29,7 @@
             </dict>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.6.0</string>
+        <string>1.1</string>
         <key>ParentRecipe</key>
         <string>com.github.autopkg.download.Silverlight</string>
         <key>Process</key>

--- a/Silverlight/Silverlight.pkg.recipe
+++ b/Silverlight/Silverlight.pkg.recipe
@@ -12,7 +12,7 @@
             <string>Silverlight</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.6.0</string>
+        <string>1.1</string>
         <key>ParentRecipe</key>
         <string>com.github.autopkg.download.Silverlight</string>
         <key>Process</key>

--- a/The Unarchiver/TheUnarchiver.download.recipe
+++ b/The Unarchiver/TheUnarchiver.download.recipe
@@ -22,12 +22,6 @@
             <string>SparkleUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>
-                <key>appcast_request_headers</key>
-                <dict>
-                    <!-- Didn't seem to like urllib as a UA -->
-                    <key>User-Agent</key>
-                    <string>curl/7.43.0</string>
-                </dict>
                 <key>appcast_url</key>
                 <string>%SPARKLE_FEED_URL%</string>
             </dict>

--- a/XQuartz/XQuartz.munki.recipe
+++ b/XQuartz/XQuartz.munki.recipe
@@ -37,7 +37,7 @@ The XQuartz project is an open-source effort to develop a version of the X.Org X
             </dict>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.2.0</string>
+        <string>0.2.5</string>
         <key>ParentRecipe</key>
         <string>com.github.autopkg.download.xquartz</string>
         <key>Process</key>


### PR DESCRIPTION
This PR includes updates to the pre-commit config, including:

- addition of AutoPkg-specific checks from my [pre-commit-macadmin](https://github.com/homebysix/pre-commit-macadmin) repo
- MinimumVersion updates where needed in order to match processors used in the recipe
- avoidance of NAME input variable if overriding its value would break a process (e.g. Copier or CodeSignatureVerifier)
- ensuring EndOfCheckPhase is included after completion of a download process
- ensuring pkg type recipes have a clear pkg output, e.g. PkgCopier or PkgCreator

Pre-commit exclusions have been made for several recipe families (like munkitools, OmniGroup, and AutoPkgGitMaster) that don't follow usual AutoPkg recipe type conventions.

The remaining failure will be solved by eventual removal of the deprecated AdobeReaderDC.pkg.recipe, and can be ignored.

```
% pre-commit run --all-files
Check AutoPkg Recipes....................................................Failed
- hook id: check-autopkg-recipes
- exit code: 1

AdobeReader/AdobeReaderDC.pkg.recipe: Recipe type pkg should contain one of these processors: ['AppPkgCreator', 'PkgCreator', 'PkgCopier'].

Forbid AutoPkg Overrides.................................................Passed
Forbid AutoPkg Trust Info................................................Passed
black....................................................................Passed
isort....................................................................Passed
seed isort known_third_party.............................................Passed
flake8...................................................................Passed
```