### PR TITLE
Add installcheck_script to AdobeReader.munki.recipe

### DIFF
--- a/AdobeReader/AdobeReader.munki.recipe
+++ b/AdobeReader/AdobeReader.munki.recipe
@@ -68,10 +68,10 @@ exit 0
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkg_unpack</string>
 				<key>flat_pkg_path</key>
 				<string>%pathname%/*.pkg</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/pkg_unpack</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
@@ -81,10 +81,10 @@ exit 0
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgdirs</key>
-				<dict/>
 				<key>pkgroot</key>
 				<string>%RECIPE_CACHE_DIR%/application_payload/Applications</string>
+				<key>pkgdirs</key>
+				<dict/>
 			</dict>
 			<key>Processor</key>
 			<string>PkgRootCreator</string>
@@ -92,10 +92,10 @@ exit 0
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/application_payload/Applications</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/pkg_unpack/application.pkg/Payload</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/application_payload/Applications</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
@@ -105,20 +105,11 @@ exit 0
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/application_payload/Applications/*.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>FileFinder</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>faux_root</key>
 				<string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
 				<array>
-					<string>/Applications/%found_basename%</string>
+					<string>/Applications/Adobe Acrobat Reader.app</string>
 				</array>
 			</dict>
 			<key>Processor</key>
@@ -131,6 +122,132 @@ exit 0
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>info_path</key>
+				<string>%RECIPE_CACHE_DIR%/application_payload/Applications/Adobe Acrobat Reader.app/Contents/Info.plist</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleShortVersionString</key>
+					<string>app_version</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PlistReader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%app_version%</string>
+					<key>installcheck_script</key>
+					<string>#!/usr/local/munki/munki-python
+
+import os
+import plistlib
+import sys
+sys.path.insert(0, &apos;/usr/local/munki&apos;)
+from munkilib.pkgutils import MunkiLooseVersion as LooseVersion
+
+def read_plist(plist_path):
+	&quot;&quot;&quot;Reads a plist file and returns its contents as a dictionary.&quot;&quot;&quot;
+	print(f&quot;Reading plist from: {plist_path}&quot;)
+	if os.path.exists(plist_path):
+		with open(plist_path, &apos;rb&apos;) as plist_file:
+			return plistlib.load(plist_file)
+	else:
+		print(f&quot;Plist not found: {plist_path}&quot;)
+		return None
+
+def check_acrobat_installed():
+	&quot;&quot;&quot;Check if Adobe Acrobat.app exists and if AcroSCA key is True.&quot;&quot;&quot;
+	acrobat_app_path = &apos;/Applications/Adobe Acrobat DC/Adobe Acrobat.app&apos;
+	acrobat_plist_path = os.path.join(acrobat_app_path, &apos;Contents&apos;, &apos;Info.plist&apos;)
+
+	# Check if Adobe Acrobat.app exists
+	if not os.path.exists(acrobat_app_path):
+		print(&quot;Adobe Acrobat DC is not installed.&quot;)
+		return False
+
+	# Read the Info.plist of Adobe Acrobat.app
+	print(&quot;Adobe Acrobat DC is installed, checking Info.plist...&quot;)
+	acrobat_plist = read_plist(acrobat_plist_path)
+	if acrobat_plist is None:
+		print(&quot;Failed to read Info.plist for Adobe Acrobat DC.&quot;)
+		return False
+
+	# Check if the AcroSCA key exists and if it&apos;s True
+	acrosca = acrobat_plist.get(&apos;AcroSCA&apos;, False)
+	print(f&quot;AcroSCA value: {acrosca}&quot;)
+	return acrosca is True
+
+def main():
+	# Check if Adobe Acrobat is installed and the AcroSCA key is True
+	print(&quot;Checking if Adobe Acrobat is installed and AcroSCA key is True...&quot;)
+	if check_acrobat_installed():
+		print(&quot;AcroSCA key is True Unified App is installed. Exiting Install...&quot;)
+		sys.exit(1)
+
+	# Check if Adobe Acrobat Reader is installed
+	reader_app_path = &apos;/Applications/Adobe Acrobat Reader.app&apos;
+	reader_plist_path = os.path.join(reader_app_path, &apos;Contents&apos;, &apos;Info.plist&apos;)
+
+	# If Adobe Acrobat Reader.app is not installed, exit with status 0
+	if not os.path.exists(reader_app_path):
+		print(&quot;Adobe Acrobat Reader is not installed. Continuing with Install...&quot;)
+		sys.exit(0)
+
+	# Read the version of Adobe Acrobat Reader
+	print(f&quot;Adobe Acrobat Reader is installed. Reading version from: {reader_plist_path}...&quot;)
+	reader_plist = read_plist(reader_plist_path)
+	if reader_plist is None:
+		print(&quot;Failed to read Info.plist for Adobe Acrobat Reader.&quot;)
+		sys.exit(0)
+
+	reader_version = reader_plist.get(&apos;CFBundleShortVersionString&apos;, None)
+	if not reader_version:
+		print(&quot;No version found for Adobe Acrobat Reader. Continuing with Install...&quot;)
+		sys.exit(0)
+
+	print(f&quot;Found Adobe Acrobat Reader version: {reader_version}&quot;)
+
+	# Get the threshold version
+	threshold_version = &apos;%app_version%&apos;  # Replace with actual threshold version string
+
+	if not threshold_version:
+		print(&quot;Threshold version is not set. Exiting...&quot;)
+		sys.exit(1)
+
+	print(f&quot;Comparing against threshold version: {threshold_version}&quot;)
+
+	# Use MunkiLooseVersion for comparing the versions
+	try:
+		reader_version_obj = LooseVersion(reader_version)
+		threshold_version_obj = LooseVersion(threshold_version)
+
+		# If Reader version is less than the threshold version, exit with status 0 (no installation needed)
+		if reader_version_obj &lt; threshold_version_obj:
+			print(f&quot;Adobe Acrobat Reader version {reader_version} is less than the threshold version {threshold_version}. Continuing with Install....&quot;)
+			sys.exit(0)
+
+		# Otherwise, exit with status 1 (indicating an installation is needed)
+		print(f&quot;Adobe Acrobat Reader version {reader_version} is greater than or equal to the threshold version {threshold_version}. Exiting Install...&quot;)
+		sys.exit(1)
+
+	except ValueError as e:
+		print(f&quot;Error comparing versions: {e}. Exiting...&quot;)
+		sys.exit(1)
+
+if __name__ == &apos;__main__&apos;:
+	main()</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
@@ -138,6 +255,18 @@ exit 0
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/pkg_unpack</string>
+					<string>%RECIPE_CACHE_DIR%/application_payload</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, Folks 

Adobe has recently released a new Unified Adobe Acrobat Application that is replacing the old Reader, Pro and DC Applications. 

Adobe Acrobat Reader can't be installed if the unified App has been installed. If you try, the install will fail with something like this in the logs
```
2024-11-19 16:10:55+01 DJPMTF4XJV package_script_service[28070]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.VttV6V/Scripts/com.adobe.acrobat.DC.reader.app.pkg.MUI.bO5Q4q
2024-11-19 16:10:56+01 DJPMTF4XJV package_script_service[28070]: ./preinstall: 2024-11-19 16:10:56.846 AcroInstallAlert[48695:416203] [1201]:: url for temp-file: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/TempFileForLangPack.pdf
2024-11-19 16:10:56+01 DJPMTF4XJV package_script_service[28070]: ./preinstall: 2024-11-19 16:10:56.853 AcroInstallAlert[48695:416203] [1202]:1: Removing item at path {/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/TempFileForLangPack.pdf}
2024-11-19 16:10:56+01 DJPMTF4XJV package_script_service[28070]: ./preinstall: 2024-11-19 16:10:56.855 AcroInstallAlert[48695:416203] INFO : Version of existing product is higher
2024-11-19 16:10:56+01 DJPMTF4XJV package_script_service[28070]: ./preinstall: 2024-11-19 16:10:56.861 AcroInstallAlert[48695:416203] ERROR [CoEx]: Adobe Acrobat is already installed at /Applications/Adobe Acrobat DC/Adobe Acrobat.app. Uninstall it and run this installer again.. 
```

The Acrobat Unified Applicaton also has logic in the installers to uninstall Adobe Acrobat Reader if it's found, resulting in looping installs.

Unfortunately there isn't any official documentation from Adobe (yet) around this, but we've found the key in `/Library/Preferences/com.adobe.Acrobat.Pro.plist` that tells us whether the unified App is installed 
```
<key>AcroSCA</key>
<true/>
```

There is further information available in this MacAdmins Slack thread: https://macadmins.slack.com/archives/C0653D6F9/p1733394538021829

I've written some recipes that will download the new Unified Application and enable reader mode, I would say it's worth folks migrating Reader to these: https://github.com/autopkg/dataJAR-recipes/tree/master/Adobe%20Acrobat%20DC%20Unified%20Application

This PR adds and an `installcheck_script` that we have been running internally for a couple of months that will check whether the unified App is installed and exit if found. 

Output from a successful -v run 
```
autopkg run -v AdobeReader.munki.recipe
Looking for com.github.autopkg.download.AdobeReader...
Did not find com.github.autopkg.download.AdobeReader in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.autopkg.download.AdobeReader...
Found com.github.autopkg.download.AdobeReader in recipe map
**load_recipe time: 0.014350833997013979
Processing AdobeReader.munki.recipe...
WARNING: AdobeReader.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
AdobeReaderURLProvider
AdobeReaderURLProvider: [displayName] : Reader 2024.005.20414 for Mac
AdobeReaderURLProvider: [version]     : 24.005.20414
AdobeReaderURLProvider: [download_url]: https://ardownload2.adobe.com/pub/adobe/reader/mac/AcrobatDC/2400520414/AcroRdrDC_2400520414_MUI.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 17 Feb 2025 10:12:05 GMT
URLDownloader: Storing new ETag header: "23732f69-62e53c1920740"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/downloads/AdobeReader.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/downloads/AdobeReader.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.4f7R5l/AcroRdrDC_2400520414_MUI.pkg' matched from globbed '/private/tmp/dmg.4f7R5l/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AcroRdrDC_2400520414_MUI.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-02-14 10:48:36 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Adobe Inc. (JQ525L2MZD)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            97 9A 81 BE 07 15 BA 87 99 0E AD DC AE 97 A7 98 08 19 8A 1E DE 0F 
CodeSignatureVerifier:            4A 42 0D CE 38 96 80 A1 CE BF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/downloads/AdobeReader.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.hqMu3y/AcroRdrDC_2400520414_MUI.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/pkg_unpack
PkgRootCreator
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/application_payload/Applications
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/pkg_unpack/application.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/application_payload/Applications
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Adobe Acrobat Reader.app
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.adobe.Reader', 'CFBundleName': 'Acrobat Reader', 'CFBundleShortVersionString': '24.005.20414', 'CFBundleVersion': '24.005.20414', 'minosversion': '12.0', 'path': '/Applications/Adobe Acrobat Reader.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
PlistReader
PlistReader: Reading: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/application_payload/Applications/Adobe Acrobat Reader.app/Contents/Info.plist
PlistReader: Assigning value of '24.005.20414' to output variable 'app_version'
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '24.005.20414', 'installcheck_script': '#!/usr/local/munki/munki-python\n\nimport os\nimport plistlib\nimport sys\nsys.path.insert(0, \'/usr/local/munki\')\nfrom munkilib.pkgutils import MunkiLooseVersion as LooseVersion\n\ndef read_plist(plist_path):\n    """Reads a plist file and returns its contents as a dictionary."""\n    print(f"Reading plist from: {plist_path}")\n    if os.path.exists(plist_path):\n        with open(plist_path, \'rb\') as plist_file:\n            return plistlib.load(plist_file)\n    else:\n        print(f"Plist not found: {plist_path}")\n        return None\n\ndef check_acrobat_installed():\n    """Check if Adobe Acrobat.app exists and if AcroSCA key is True."""\n    acrobat_app_path = \'/Applications/Adobe Acrobat DC/Adobe Acrobat.app\'\n    acrobat_plist_path = os.path.join(acrobat_app_path, \'Contents\', \'Info.plist\')\n\n    # Check if Adobe Acrobat.app exists\n    if not os.path.exists(acrobat_app_path):\n        print("Adobe Acrobat DC is not installed.")\n        return False\n\n    # Read the Info.plist of Adobe Acrobat.app\n    print("Adobe Acrobat DC is installed, checking Info.plist...")\n    acrobat_plist = read_plist(acrobat_plist_path)\n    if acrobat_plist is None:\n        print("Failed to read Info.plist for Adobe Acrobat DC.")\n        return False\n\n    # Check if the AcroSCA key exists and if it\'s True\n    acrosca = acrobat_plist.get(\'AcroSCA\', False)\n    print(f"AcroSCA value: {acrosca}")\n    return acrosca is True\n\ndef main():\n    # Check if Adobe Acrobat is installed and the AcroSCA key is True\n    print("Checking if Adobe Acrobat is installed and AcroSCA key is True...")\n    if check_acrobat_installed():\n        print("AcroSCA key is True Unified App is installed. Exiting Install...")\n        sys.exit(1)\n\n    # Check if Adobe Acrobat Reader is installed\n    reader_app_path = \'/Applications/Adobe Acrobat Reader.app\'\n    reader_plist_path = os.path.join(reader_app_path, \'Contents\', \'Info.plist\')\n\n    # If Adobe Acrobat Reader.app is not installed, exit with status 0\n    if not os.path.exists(reader_app_path):\n        print("Adobe Acrobat Reader is not installed. Continuing with Install...")\n        sys.exit(0)\n\n    # Read the version of Adobe Acrobat Reader\n    print(f"Adobe Acrobat Reader is installed. Reading version from: {reader_plist_path}...")\n    reader_plist = read_plist(reader_plist_path)\n    if reader_plist is None:\n        print("Failed to read Info.plist for Adobe Acrobat Reader.")\n        sys.exit(0)\n\n    reader_version = reader_plist.get(\'CFBundleShortVersionString\', None)\n    if not reader_version:\n        print("No version found for Adobe Acrobat Reader. Continuing with Install...")\n        sys.exit(0)\n\n    print(f"Found Adobe Acrobat Reader version: {reader_version}")\n\n    # Get the threshold version\n    threshold_version = \'24.005.20414\'  # Replace with actual threshold version string\n\n    if not threshold_version:\n        print("Threshold version is not set. Exiting...")\n        sys.exit(1)\n\n    print(f"Comparing against threshold version: {threshold_version}")\n\n    # Use MunkiLooseVersion for comparing the versions\n    try:\n        reader_version_obj = LooseVersion(reader_version)\n        threshold_version_obj = LooseVersion(threshold_version)\n\n        # If Reader version is less than the threshold version, exit with status 0 (no installation needed)\n        if reader_version_obj < threshold_version_obj:\n            print(f"Adobe Acrobat Reader version {reader_version} is less than the threshold version {threshold_version}. Continuing with Install....")\n            sys.exit(0)\n\n        # Otherwise, exit with status 1 (indicating an installation is needed)\n        print(f"Adobe Acrobat Reader version {reader_version} is greater than or equal to the threshold version {threshold_version}. Exiting Install...")\n        sys.exit(1)\n\n    except ValueError as e:\n        print(f"Error comparing versions: {e}. Exiting...")\n        sys.exit(1)\n\nif __name__ == \'__main__\':\n    main()'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Adobe/AdobeReader-24.005.20414.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Adobe/AdobeReader-24.005.20414.dmg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/pkg_unpack
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/application_payload
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/receipts/AdobeReader.munki-receipt-20250221-103349.plist

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/downloads/AdobeReader.dmg  

The following new items were imported into Munki:
    Name         Version       Catalogs  Pkginfo Path                               Pkg Repo Path                            Icon Repo Path  
    ----         -------       --------  ------------                               -------------                            --------------  
    AdobeReader  24.005.20414  testing   apps/Adobe/AdobeReader-24.005.20414.plist  apps/Adobe/AdobeReader-24.005.20414.dmg
```