### PR TITLE
Cleanup temp app bundle and DMG for TextMate2 recipes

### DIFF
--- a/TextMate/TextMate2.install.recipe
+++ b/TextMate/TextMate2.install.recipe
@@ -47,17 +47,17 @@
             </dict>
         </dict>
         <dict>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
-		</dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/TextMate/TextMate2.install.recipe
+++ b/TextMate/TextMate2.install.recipe
@@ -46,6 +46,18 @@
                 </array>
             </dict>
         </dict>
+        <dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
     </array>
 </dict>
 </plist>

--- a/TextMate/TextMate2.munki.recipe
+++ b/TextMate/TextMate2.munki.recipe
@@ -76,6 +76,18 @@ i.e.: `-k PRERELEASE=yes`
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
+        <dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
     </array>
 </dict>
 </plist>

--- a/TextMate/TextMate2.munki.recipe
+++ b/TextMate/TextMate2.munki.recipe
@@ -77,17 +77,17 @@ i.e.: `-k PRERELEASE=yes`
             <string>MunkiImporter</string>
         </dict>
         <dict>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
-		</dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi there 👋

The **TextMate2** recipes leave residual app bundles + DMGs around, so this PR attempts to cleanup files that are no longer required.

Should save approximately **40MB** of disk space per recipe!