### PR TITLE
Fix misspelling in Skype deprecation warnings

### DIFF
--- a/Skype/Skype.download.recipe
+++ b/Skype/Skype.download.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe has been deprecated. As of May 2025, Microsoft has discontuned Skype. Please remove this recipe from your runs.
+                <string>This recipe has been deprecated. As of May 2025, Microsoft has discontinued Skype. Please remove this recipe from your runs.
 
 For more details, see https://support.microsoft.com/en-us/skype/skype-is-retiring-in-may-2025-what-you-need-to-know-2a7d2501-427f-485e-8be0-2068a9f90472</string>
             </dict>

--- a/Skype/Skype.install.recipe
+++ b/Skype/Skype.install.recipe
@@ -20,7 +20,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe has been deprecated. As of May 2025, Microsoft has discontuned Skype. Please remove this recipe from your runs.
+                <string>This recipe has been deprecated. As of May 2025, Microsoft has discontinued Skype. Please remove this recipe from your runs.
 
 For more details, see https://support.microsoft.com/en-us/skype/skype-is-retiring-in-may-2025-what-you-need-to-know-2a7d2501-427f-485e-8be0-2068a9f90472</string>
             </dict>

--- a/Skype/Skype.munki.recipe
+++ b/Skype/Skype.munki.recipe
@@ -40,7 +40,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>This recipe has been deprecated. As of May 2025, Microsoft has discontuned Skype. Please remove this recipe from your runs.
+                <string>This recipe has been deprecated. As of May 2025, Microsoft has discontinued Skype. Please remove this recipe from your runs.
 
 For more details, see https://support.microsoft.com/en-us/skype/skype-is-retiring-in-may-2025-what-you-need-to-know-2a7d2501-427f-485e-8be0-2068a9f90472</string>
             </dict>

--- a/Skype/Skype.pkg.recipe
+++ b/Skype/Skype.pkg.recipe
@@ -25,7 +25,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>warning_message</key>
-                    <string>This recipe has been deprecated. As of May 2025, Microsoft has discontuned Skype. Please remove this recipe from your runs.
+                    <string>This recipe has been deprecated. As of May 2025, Microsoft has discontinued Skype. Please remove this recipe from your runs.
 
 For more details, see https://support.microsoft.com/en-us/skype/skype-is-retiring-in-may-2025-what-you-need-to-know-2a7d2501-427f-485e-8be0-2068a9f90472</string>
                 </dict>


### PR DESCRIPTION
Misspelled `discontinued` as `discontuned` 