### PR TITLE
Fix Praat Search Regex

### DIFF
--- a/Praat/Praat.download.recipe
+++ b/Praat/Praat.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>a href="?(praat\d+_mac.dmg)"?</string>
+				<string>https:\/\/github\.com\/praat\/praat\/releases\/download\/v[\d.]+\/(praat\d+_mac.dmg)</string>
 				<key>result_output_var_name</key>
 				<string>dl_filename</string>
 				<key>url</key>


### PR DESCRIPTION
Hi there, 

The Praat.download.recipe showed a URLTextSearcher error when searching for the filename.
I fixed the problem by changing the regex:
- old re_pattern: `a href="?(praat\d+_mac.dmg)"?`
- new re_pattern: `https:\/\/github\.com\/praat\/praat\/releases\/download\/v[\d.]+\/(praat\d+_mac.dmg)`