### PR TITLE
Enable pip-upgrade when calling relocatable-python for AutoPkgGitMaster.pkg recipe

### DIFF
--- a/AutoPkg/AutoPkgGitMaster.pkg.recipe
+++ b/AutoPkg/AutoPkgGitMaster.pkg.recipe
@@ -17,14 +17,14 @@ This is not used to obtain the latest released version.
             <key>URL</key>
             <string>https://github.com/autopkg/autopkg/zipball/</string>
             <key>PYTHON_VERSION</key>
-            <string>3.7.5</string>
+            <string>3.10.4</string>
             <key>REQUIREMENTS_FILENAME</key>
-            <string>requirements.txt</string>
+            <string>new_requirements.txt</string>
             <key>OS_VERSION</key>
-            <string>10.9</string>
+            <string>11</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.2.1</string>
+        <string>2.3</string>
         <key>Process</key>
         <array>
             <dict>

--- a/AutoPkg/AutoPkgGitMaster.pkg.recipe
+++ b/AutoPkg/AutoPkgGitMaster.pkg.recipe
@@ -90,6 +90,8 @@ This is not used to obtain the latest released version.
                     <string>%PYTHON_VERSION%</string>
                     <key>os_version</key>
                     <string>%OS_VERSION%</string>
+                    <key>upgrade_pip</key>
+                    <string>true</string>
                 </dict>
                 <key>Processor</key>
                 <string>GenerateRelocatablePython</string>

--- a/AutoPkg/GenerateRelocatablePython.py
+++ b/AutoPkg/GenerateRelocatablePython.py
@@ -43,6 +43,10 @@ class GenerateRelocatablePython(Processor):
             "required": True,
             "description": "What OS to fetch.",
         },
+        "upgrade_pip": {
+            "required": False,
+            "description": "Whether to upgrade pip to the latest version.",
+        },
     }
     output_variables = {
         "python_path": {"description": "Path to built Python framework."}
@@ -80,6 +84,8 @@ class GenerateRelocatablePython(Processor):
             "--destination",
             dest,
         ]
+        if self.env.get("upgrade_pip"):
+            cmd.append("--upgrade-pip")
         self.output("Building relocatable python framework...")
         self.output(f"Command: {' '.join(cmd)}", verbose_level=4)
         try:


### PR DESCRIPTION
This change enables the ability to include `--upgrade-pip` in the call to relocatable-python when building new releases of AutoPkg.

In the process of building AutoPkg, I found that including the latest version of pip solved a build error (details below).

<details><summary>Relocatable-python building to AutoPkg 2.7.5 requirements without `--upgrade-pip`</summary>

```
% '/usr/local/autopkg/python' 'make_relocatable_python_framework.py' '--python-version' '3.10.4' '--pip-requirements' '~/Developer/autopkg/new_requirements.txt' '--os-version' '11' '--destination' '/tmp/Python.framework'
[...]
      Modules/objc/ctests.m:1063:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1063 | static PyMethodDef mod_methods[] = {TESTDEF(CheckNSInvoke),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1065:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1065 |                                     TESTDEF(VectorSize),
            |                                     ^~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1066:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1066 |                                     TESTDEF(VectorAlign),
            |                                     ^~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1067:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1067 |                                     TESTDEF(StructSize),
            |                                     ^~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1068:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1068 |                                     TESTDEF(StructAlign),
            |                                     ^~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1069:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1069 |                                     TESTDEF(FillStruct1),
            |                                     ^~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1070:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1070 |                                     TESTDEF(FillStruct2),
            |                                     ^~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1071:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1071 |                                     TESTDEF(FillStruct3),
            |                                     ^~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1072:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1072 |                                     TESTDEF(FillStruct4),
            |                                     ^~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1073:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1073 |                                     TESTDEF(FillStruct5Array),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1074:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1074 |                                     TESTDEF(ExtractStruct1),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1075:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1075 |                                     TESTDEF(ExtractStruct2),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1076:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1076 |                                     TESTDEF(ExtractStruct3),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1077:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1077 |                                     TESTDEF(ExtractStruct4),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1078:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1078 |                                     TESTDEF(ExtractStruct5Array),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1080:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1080 |                                     TESTDEF(TestSizeOfBool),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1082:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1082 |                                     TESTDEF(TestTypeCode),
            |                                     ^~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1083:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1083 |                                     TESTDEF(TestSimplifySignature),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/ctests.m:1084:37: error: cast from 'PyObject * _Nullable (*)(PyObject * _Nonnull)' (aka 'struct _object * _Nullable (*)(struct _object * _Nonnull)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
       1084 |                                     TESTDEF(TestArrayCoding),
            |                                     ^~~~~~~~~~~~~~~~~~~~~~~~
      Modules/objc/pyobjc-unittest.h:122:38: note: expanded from macro 'TESTDEF'
        122 |         .ml_name = #name, .ml_meth = (PyCFunction)test_##name, .ml_flags = METH_NOARGS,  \
            |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
      fatal error: too many errors emitted, stopping now [-ferror-limit=]
      20 errors generated.
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pyobjc-core
  Building wheel for pyobjc-framework-CFNetwork (pyproject.toml) ... done
  Created wheel for pyobjc-framework-CFNetwork: filename=pyobjc_framework_cfnetwork-9.2-cp36-abi3-macosx_10_9_universal2.whl size=19006 sha256=a4b52a70e64b93dc325196cede3ca960dbf0d8530b21e1012fa51b11b6eed153
  Stored in directory: ~/Library/Caches/pip/wheels/1a/b8/66/35a4086bf84d0c5311c82e077e08921f867870a6c865f22b94
  Building wheel for pyobjc-framework-LaunchServices (pyproject.toml) ... done
  Created wheel for pyobjc-framework-LaunchServices: filename=pyobjc_framework_launchservices-9.2-py2.py3-none-any.whl size=3446 sha256=a19c8d72795d09495713fce84f73312b10a1a06c5eff64c153f20ca54f0952c4
  Stored in directory: ~/Library/Caches/pip/wheels/e6/46/ef/74004b3d5c422781f0b1dae3dfbbf86f4f10422e0c85ee6e83
  Building wheel for pyobjc-framework-OpenDirectory (pyproject.toml) ... done
  Created wheel for pyobjc-framework-OpenDirectory: filename=pyobjc_framework_opendirectory-9.2-py2.py3-none-any.whl size=11281 sha256=6106fa741b26f341e35244fcc240b90f5cebab1ce7d945a93a78a27484e16bdb
  Stored in directory: ~/Library/Caches/pip/wheels/ce/00/a4/a1a248fc3de443252ac051e098fc7873789df88db4eb504ddf
  Building wheel for pyobjc-framework-Quartz (pyproject.toml) ... done
  Created wheel for pyobjc-framework-Quartz: filename=pyobjc_framework_quartz-9.2-cp310-cp310-macosx_10_9_universal2.whl size=211441 sha256=535b0766278991071b531cc43776bd53c5baa643109b574c49cf8ae9f60ebfa1
  Stored in directory: ~/Library/Caches/pip/wheels/7e/75/6b/516f59b65e060bf394ba41211b0a90458774a62b761b37080b
  Building wheel for pyobjc-framework-Security (pyproject.toml) ... done
  Created wheel for pyobjc-framework-Security: filename=pyobjc_framework_security-9.2-cp310-cp310-macosx_10_9_universal2.whl size=40386 sha256=acf247069a25301aa08e1cbe375f6fd5682d56f038d22e1cd4ecb08f749c9bcc
  Stored in directory: ~/Library/Caches/pip/wheels/70/15/91/3f1a706c3cc72cf07c6fd36688b5769a8433cb25d8aaa7e358
  Building wheel for pyobjc-framework-SystemConfiguration (pyproject.toml) ... done
  Created wheel for pyobjc-framework-SystemConfiguration: filename=pyobjc_framework_systemconfiguration-9.2-cp36-abi3-macosx_10_9_universal2.whl size=21585 sha256=35dbf5dfb266354befee12af857b54598be2c6787225576788fdb2d3736ff458
  Stored in directory: ~/Library/Caches/pip/wheels/6f/52/e5/3aaab70e2c33dfa3b91fdd5e151a773419fbc60feb0951d592
  Building wheel for pyobjc-framework-Cocoa (pyproject.toml) ... done
  Created wheel for pyobjc-framework-Cocoa: filename=pyobjc_framework_cocoa-9.2-cp310-cp310-macosx_10_9_universal2.whl size=379429 sha256=3457dc02e85e8cb0032f9d9157b6ef0a3bef3b6d58b99465944bfb8161474900
  Stored in directory: ~/Library/Caches/pip/wheels/a3/65/e3/a5ac7707941a16aadd26938553d10313f3d828933d712d09a9
  Building wheel for pyobjc-framework-CoreServices (pyproject.toml) ... done
  Created wheel for pyobjc-framework-CoreServices: filename=pyobjc_framework_coreservices-9.2-cp36-abi3-macosx_10_9_universal2.whl size=29272 sha256=21c8e79860bc825f3b870bf27cb76f708ed218dfe6b796b1d1c9362c61f68203
  Stored in directory: ~/Library/Caches/pip/wheels/da/61/d3/40cbf767ae568cf9e0212c74f857230540d4c766e98f0304fc
  Building wheel for pyobjc-framework-FSEvents (pyproject.toml) ... done
  Created wheel for pyobjc-framework-FSEvents: filename=pyobjc_framework_fsevents-9.2-cp36-abi3-macosx_10_9_universal2.whl size=12842 sha256=da6380b4aeece94a71895478978f78ece19b7d41b0b85e1ce0844cc7e3f7da4b
  Stored in directory: ~/Library/Caches/pip/wheels/f0/94/56/35d250117564e375c1055c824c7d7c4c19b6cce927cd8e4514
Successfully built attrs black filelock flake8-bugbear isort platformdirs PyYAML tomli virtualenv pyobjc-framework-CFNetwork pyobjc-framework-LaunchServices pyobjc-framework-OpenDirectory pyobjc-framework-Quartz pyobjc-framework-Security pyobjc-framework-SystemConfiguration pyobjc-framework-Cocoa pyobjc-framework-CoreServices pyobjc-framework-FSEvents
Failed to build pyobjc-core
ERROR: Could not build wheels for pyobjc-core, which is required to install pyproject.toml-based projects
WARNING: You are using pip version 22.0.4; however, version 25.1.1 is available.
You should consider upgrading via the '/private/tmp/Python.framework/Versions/3.10/bin/python3.10 -m pip install --upgrade pip' command.
Traceback (most recent call last):
  File "~/Developer/_cloned/relocatable-python/make_relocatable_python_framework.py", line 108, in <module>
    main()
  File "~/Developer/_cloned/relocatable-python/make_relocatable_python_framework.py", line 94, in main
    install_extras(
  File "~/Developer/_cloned/relocatable-python/locallibs/install.py", line 114, in install_extras
    install_requirements(requirements_file, framework_path, version)
  File "~/Developer/_cloned/relocatable-python/locallibs/install.py", line 79, in install_requirements
    subprocess.check_call(cmd, env=pip_env)
  File "/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/tmp/Python.framework/Versions/3.10/bin/python3.10', '-s', '-m', 'pip', 'install', '-r', '~/Developer/autopkg/new_requirements.txt']' returned non-zero exit status 1.
```
</summary></details>

<details><summary>Relocatable-python building to AutoPkg 2.7.5 requirements WITH `--upgrade-pip`</summary>

```
% '/usr/local/autopkg/python' 'make_relocatable_python_framework.py' '--python-version' '3.10.4' '--pip-requirements' '~/Developer/autopkg/new_requirements.txt' '--os-version' '11' '--destination' '/tmp/Python.framework' --upgrade-pip
[...]
  Using cached pyobjc_framework_FSEvents-9.2-cp36-abi3-macosx_10_9_universal2.whl
Installing collected packages: nodeenv, mypy-extensions, mccabe, distlib, appdirs, tomli, toml, six, PyYAML, pyobjc-core, pyflakes, pycparser, pycodestyle, platformdirs, pathspec, isort, identify, filelock, click, cfgv, certifi, attrs, virtualenv, pyobjc-framework-Cocoa, flake8, cffi, black, xattr, pyobjc-framework-SystemConfiguration, pyobjc-framework-Security, pyobjc-framework-Quartz, pyobjc-framework-OpenDirectory, pyobjc-framework-FSEvents, pyobjc-framework-CFNetwork, pre-commit, flake8-bugbear, pyobjc-framework-CoreServices, pyobjc-framework-LaunchServices
Successfully installed PyYAML-6.0.1 appdirs-1.4.4 attrs-21.4.0 black-22.3.0 certifi-2023.7.22 cffi-1.15.0 cfgv-3.3.1 click-8.1.0 distlib-0.3.4 filelock-3.6.0 flake8-4.0.1 flake8-bugbear-22.3.23 identify-2.4.12 isort-5.12.0 mccabe-0.6.1 mypy-extensions-0.4.3 nodeenv-1.6.0 pathspec-0.9.0 platformdirs-2.5.1 pre-commit-2.17.0 pycodestyle-2.8.0 pycparser-2.21 pyflakes-2.4.0 pyobjc-core-9.2 pyobjc-framework-CFNetwork-9.2 pyobjc-framework-Cocoa-9.2 pyobjc-framework-CoreServices-9.2 pyobjc-framework-FSEvents-9.2 pyobjc-framework-LaunchServices-9.2 pyobjc-framework-OpenDirectory-9.2 pyobjc-framework-Quartz-9.2 pyobjc-framework-Security-9.2 pyobjc-framework-SystemConfiguration-9.2 six-1.16.0 toml-0.10.2 tomli-2.0.1 virtualenv-20.14.0 xattr-0.9.7
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/idle3.10...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/pycodestyle...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/nodeenv...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/isort-identify-imports...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/identify-cli...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/flake8...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/pip3...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/wheel...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/python3.10-config...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/isort...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/pydoc3.10...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/pip...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/2to3-3.10...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/pip3.10...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/pre-commit-validate-manifest...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/blackd...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/pre-commit-validate-config...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/virtualenv...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/black...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/pre-commit...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/pyflakes...
Modifying shebang for /tmp/Python.framework/Versions/3.10/bin/xattr...

Done!
Customized, relocatable framework is at /tmp/Python.framework
```
</details>