### PR TITLE
Fix Praat Search Regex to find latest version

### DIFF
--- a/Praat/Praat.download.recipe
+++ b/Praat/Praat.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https:\/\/github\.com\/praat\/praat\/releases\/download\/v[\d.]+\/(praat\d+_mac.dmg)</string>
+				<string>href="(praat\d+_mac.dmg)"&gt;praat\d+_mac.dmg</string>
 				<key>result_output_var_name</key>
 				<string>dl_filename</string>
 				<key>url</key>


### PR DESCRIPTION
Hi folks, 

The Praat.download.recipe showed a URLDownloader error because of a wrong output of the URLTextSearcher (finds version 6309 instead of 6438).
I fixed it again by changing the regex:

old re_pattern: `https:\/\/github\.com\/praat\/praat\/releases\/download\/v[\d.]+\/(praat\d+_mac.dmg)`
new re_pattern: `href="(praat\d+_mac.dmg)"&gt;praat\d+_mac.dmg`