### PR TITLE
Update AdobeReader.munki.recipe

### DIFF
--- a/AdobeReader/AdobeReader.munki.recipe
+++ b/AdobeReader/AdobeReader.munki.recipe
@@ -198,7 +198,7 @@ echo "No Adobe Acrobat DC Unified App found with AcroSCA=True"
 # Check if Adobe Acrobat Reader.app is installed
 reader_app_path="/Applications/Adobe Acrobat Reader.app"
 reader_plist_path="$reader_app_path/Contents/Info.plist"
-munki_version="25.001.20693"
+munki_version="app_version"
 
 echo "Checking for Adobe Acrobat Reader at: $reader_app_path"
 


### PR DESCRIPTION
Hi, folks 

This PR refactors the `installcheck_script` from `munki-python` to `zsh` for future compatibility with Munki 7

Output from a successful -v run 
```
autopkg run -v AdobeReader.munki.recipe
Looking for com.github.autopkg.download.AdobeReader...
Did not find com.github.autopkg.download.AdobeReader in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.autopkg.download.AdobeReader...
Found com.github.autopkg.download.AdobeReader in recipe map
**load_recipe time: 0.010415084001579089
Processing AdobeReader.munki.recipe...
WARNING: AdobeReader.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
AdobeReaderURLProvider
AdobeReaderURLProvider: [displayName] : Reader 2025.001.20693 for Mac
AdobeReaderURLProvider: [version]     : 25.001.20693
AdobeReaderURLProvider: [download_url]: https://ardownload3.adobe.com/pub/adobe/reader/mac/AcrobatDC/2500120693/AcroRdrDC_2500120693_MUI.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 08 Sep 2025 13:28:44 GMT
URLDownloader: Storing new ETag header: "2778ec6b-63e4a2aa55436"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/downloads/AdobeReader.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/downloads/AdobeReader.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.YFW93L/AcroRdrDC_2500120693_MUI.pkg' matched from globbed '/private/tmp/dmg.YFW93L/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AcroRdrDC_2500120693_MUI.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-09-08 01:01:19 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Adobe Inc. (JQ525L2MZD)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            97 9A 81 BE 07 15 BA 87 99 0E AD DC AE 97 A7 98 08 19 8A 1E DE 0F 
CodeSignatureVerifier:            4A 42 0D CE 38 96 80 A1 CE BF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/downloads/AdobeReader.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.T7mBUq/AcroRdrDC_2500120693_MUI.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/pkg_unpack
PkgRootCreator
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/application_payload/Applications
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/pkg_unpack/application.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/application_payload/Applications
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Adobe Acrobat Reader.app
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.adobe.Reader', 'CFBundleName': 'Acrobat Reader', 'CFBundleShortVersionString': '25.001.20693', 'CFBundleVersion': '25.001.20693', 'minosversion': '12.0', 'path': '/Applications/Adobe Acrobat Reader.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
PlistReader
PlistReader: Reading: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/application_payload/Applications/Adobe Acrobat Reader.app/Contents/Info.plist
PlistReader: Assigning value of '25.001.20693' to output variable 'app_version'
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '25.001.20693', 'installcheck_script': '#!/bin/zsh\n#\n# DESCRIPTION\n# - Exits with code 1 if Adobe Acrobat DC Unified App is installed (AcroSCA key is True).\n# - If Adobe Acrobat Reader.app is not installed, proceeds with install.\n# - If installed version is older than Munki version, proceeds with install.\n# - Otherwise, skips install.\n\n# Function to compare version strings using sort -V\ncompare_versions() {\n    local version1="$1"\n    local version2="$2"\n\n    # Use sort -V to compare versions\n    local sorted_first=$(printf \'%s\\n%s\\n\' "$version1" "$version2" | sort -V | head -n1)\n\n    if [[ "$sorted_first" == "$version1" ]] && [[ "$version1" != "$version2" ]]; then\n        # version1 is strictly less than version2\n        return 0\n    else\n        # version1 is greater than or equal to version2\n        return 1\n    fi\n}\n\n# Check for Adobe Acrobat DC Unified App with AcroSCA key\nacrobat_app_path="/Applications/Adobe Acrobat DC/Adobe Acrobat.app"\nacrobat_plist_path="$acrobat_app_path/Contents/Info.plist"\n\necho "Checking for Adobe Acrobat DC Unified App..."\n\nif [[ -f "$acrobat_plist_path" ]]; then\n    echo "Found Acrobat DC at: $acrobat_app_path"\n\n    # Check if the AcroSCA key exists and if it\'s True\n    if acrosca=$(plutil -extract AcroSCA raw "$acrobat_plist_path" 2>/dev/null); then\n        echo "AcroSCA value found: $acrosca"\n        if [[ "$acrosca" == "1" ]] || [[ "$acrosca" == "true" ]]; then\n            echo "AcroSCA key is True. Unified App is installed. Exiting install."\n            exit 1\n        else\n            echo "AcroSCA key exists but is False: $acrosca"\n        fi\n    else\n        echo "AcroSCA key not found in $acrobat_plist_path"\n    fi\nelse\n    echo "Adobe Acrobat DC not found at: $acrobat_app_path"\nfi\n\necho "No Adobe Acrobat DC Unified App found with AcroSCA=True"\n\n# Check if Adobe Acrobat Reader.app is installed\nreader_app_path="/Applications/Adobe Acrobat Reader.app"\nreader_plist_path="$reader_app_path/Contents/Info.plist"\nmunki_version="25.001.20693"\n\necho "Checking for Adobe Acrobat Reader at: $reader_app_path"\n\nif [[ ! -d "$reader_app_path" ]]; then\n    echo "Adobe Acrobat Reader is not installed. Proceeding with install..."\n    exit 0\nfi\n\necho "Adobe Acrobat Reader found. Checking version..."\n\n# Get installed version\nif installed_version=$(plutil -extract CFBundleShortVersionString raw "$reader_plist_path" 2>/dev/null); then\n    echo "Found Adobe Acrobat Reader version: $installed_version"\n    echo "Munki version to install: $munki_version"\nelse\n    echo "Failed to read version from $reader_plist_path. Proceeding with install..."\n    exit 0\nfi\n\n# Compare installed version with Munki version\nif compare_versions "$installed_version" "$munki_version"; then\n    echo "Adobe Acrobat Reader version $installed_version is older than Munki version $munki_version. Proceeding with install..."\n    exit 0\nelse\n    echo "Adobe Acrobat Reader version $installed_version is same or newer than Munki version $munki_version. Skipping install..."\n    exit 1\nfi'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Adobe/AdobeReader-25.001.20693.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Adobe/AdobeReader-25.001.20693.dmg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/pkg_unpack
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/application_payload
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/receipts/AdobeReader.munki-receipt-20250910-163630.plist

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.autopkg.munki.AdobeReader/downloads/AdobeReader.dmg  

The following new items were imported into Munki:
    Name         Version       Catalogs  Pkginfo Path                               Pkg Repo Path                            Icon Repo Path  
    ----         -------       --------  ------------                               -------------                            --------------  
    AdobeReader  25.001.20693  testing   apps/Adobe/AdobeReader-25.001.20693.plist  apps/Adobe/AdobeReader-25.001.20693.dmg
```

