### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Praat/Praat.download.recipe
+++ b/Praat/Praat.download.recipe
@@ -23,7 +23,7 @@
 				<key>result_output_var_name</key>
 				<string>dl_filename</string>
 				<key>url</key>
-				<string>http://www.fon.hum.uva.nl/praat/download_mac.html</string>
+				<string>https://www.fon.hum.uva.nl/praat/download_mac.html</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -34,7 +34,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>http://www.fon.hum.uva.nl/praat/%dl_filename%</string>
+				<string>https://www.fon.hum.uva.nl/praat/%dl_filename%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._