### PR TITLE
Create munkitools7.munki.recipe

### DIFF
--- a/munkitools/munkitools7.munki.recipe
+++ b/munkitools/munkitools7.munki.recipe
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads and imports Munki tools version 7 via the official releases listing on GitHub.
+
+You can set INCLUDE_PRERELEASES to any value to have this recipe pull prerelease versions.
+
+This recipe cannot be overridden to pull a download from an alternate location.
+
+The GitHubReleasesInfoProvider processor used by this recipe also
+respects an input variable: 'sort_by_highest_tag_names', which
+if set, will ignore the post dates of the releases and instead sort
+descending by tag names according to LooseVersion semantics.
+</string>
+    <key>Identifier</key>
+    <string>com.github.autopkg.munki.munkitools7</string>
+    <key>Input</key>
+    <dict>
+        <key>INCLUDE_PRERELEASES</key>
+        <string></string>
+        <key>NAME</key>
+        <string>munkitools</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>munkitools</string>
+        <key>MUNKI_ICON</key>
+        <string>munkitools.png</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>development</string>
+            </array>
+            <key>category</key>
+            <string>munkitools</string>
+            <key>description</key>
+            <string>Managed software installation for macOS.</string>
+            <key>developer</key>
+            <string>The Munki Project</string>
+            <key>display_name</key>
+            <string>Managed Software Center</string>
+            <key>icon_name</key>
+            <string>%MUNKI_ICON%</string>
+            <key>minimum_os_version</key>
+            <string>10.15</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>asset_regex</key>
+                <string>^munkitools-7.*?pkg$</string>
+                <key>github_repo</key>
+                <string>munki/munki</string>
+                <key>include_prereleases</key>
+                <string>%INCLUDE_PRERELEASES%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Adds a recipe for Munki 7. Now that the releases on the primary repo are signed, there doesn't appear to be a need for two recipes as there were in the past.

-vv run
[munkitools7.log](https://github.com/user-attachments/files/22660808/munkitools7.log)
