### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Adium/Adium.pkg.recipe
+++ b/Adium/Adium.pkg.recipe
@@ -77,8 +77,6 @@
                     <string>com.adiumX.adiumX.pkg</string>
                     <key>resources</key>
                     <string>Resources</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/AdobeAIR/AdobeAIR.pkg.recipe
+++ b/AdobeAIR/AdobeAIR.pkg.recipe
@@ -247,8 +247,6 @@ Based on jamesz's work here: https://github.com/jamesez/automunki/tree/master/ad
                     <string>%RECIPE_CACHE_DIR%/PackageInfo</string>
                     <key>resources</key>
                     <string>Resources</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/AutoPkg/AutoPkg1GitMaster.pkg.recipe
+++ b/AutoPkg/AutoPkg1GitMaster.pkg.recipe
@@ -248,8 +248,6 @@ This is not used to obtain the latest released version.
                         <string>%RECIPE_CACHE_DIR%/PackageInfo</string>
                         <key>resources</key>
                         <string>Resources</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>scripts</key>
                         <string>Scripts</string>
                         <key>chown</key>

--- a/AutoPkg/AutoPkgGitMaster.pkg.recipe
+++ b/AutoPkg/AutoPkgGitMaster.pkg.recipe
@@ -322,8 +322,6 @@ This is not used to obtain the latest released version.
                         <string>%RECIPE_CACHE_DIR%/PackageInfo</string>
                         <key>resources</key>
                         <string>Resources</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>scripts</key>
                         <string>Scripts</string>
                         <key>chown</key>

--- a/AutoPkg/AutoPkgGitMasterNoPython.pkg.recipe
+++ b/AutoPkg/AutoPkgGitMasterNoPython.pkg.recipe
@@ -248,8 +248,6 @@ This is not used to obtain the latest released version.
                         <string>%RECIPE_CACHE_DIR%/PackageInfo</string>
                         <key>resources</key>
                         <string>Resources</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>scripts</key>
                         <string>Scripts</string>
                         <key>chown</key>

--- a/Barebones/BBEdit.pkg.recipe
+++ b/Barebones/BBEdit.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.barebones.bbedit.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>BBEdit_Scripts</string>
                     <key>chown</key>

--- a/Cyberduck/Cyberduck.pkg.recipe
+++ b/Cyberduck/Cyberduck.pkg.recipe
@@ -70,8 +70,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>ch.sudo.cyberduck</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/GoogleChrome/GoogleChrome.pkg.recipe
+++ b/GoogleChrome/GoogleChrome.pkg.recipe
@@ -62,8 +62,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Handbrake/Handbrake.pkg.recipe
+++ b/Handbrake/Handbrake.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Mozilla/Firefox.pkg.recipe
+++ b/Mozilla/Firefox.pkg.recipe
@@ -71,8 +71,6 @@ See the following URLs for more info:
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>org.mozilla.firefox.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniGraffle.pkg.recipe
+++ b/OmniGroup/OmniGraffle.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniGraffle6.pkg.recipe
+++ b/OmniGroup/OmniGraffle6.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniGraffle7.pkg.recipe
+++ b/OmniGroup/OmniGraffle7.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniGrafflePro.pkg.recipe
+++ b/OmniGroup/OmniGrafflePro.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniGraphSketcher.pkg.recipe
+++ b/OmniGroup/OmniGraphSketcher.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniGroupProduct.pkg.recipe
+++ b/OmniGroup/OmniGroupProduct.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniOutliner.pkg.recipe
+++ b/OmniGroup/OmniOutliner.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniOutliner4.pkg.recipe
+++ b/OmniGroup/OmniOutliner4.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniOutliner5.pkg.recipe
+++ b/OmniGroup/OmniOutliner5.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniOutlinerPro.pkg.recipe
+++ b/OmniGroup/OmniOutlinerPro.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniPlan.pkg.recipe
+++ b/OmniGroup/OmniPlan.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/OmniGroup/OmniPlan3.pkg.recipe
+++ b/OmniGroup/OmniPlan3.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Panic/Coda2.pkg.recipe
+++ b/Panic/Coda2.pkg.recipe
@@ -75,8 +75,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Panic/Transmit.pkg.recipe
+++ b/Panic/Transmit.pkg.recipe
@@ -75,8 +75,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Panic/Transmit5.pkg.recipe
+++ b/Panic/Transmit5.pkg.recipe
@@ -75,8 +75,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/The Unarchiver/TheUnarchiver.pkg.recipe
+++ b/The Unarchiver/TheUnarchiver.pkg.recipe
@@ -75,8 +75,6 @@ yet in a released version. It should still download and unzip properly if is it 
                     <string>%version%</string>
                     <key>id</key>
                     <string>cx.c3.theunarchiver</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/VLC/VLC.pkg.recipe
+++ b/VLC/VLC.pkg.recipe
@@ -79,8 +79,6 @@
                     <string>org.videolan.vlc.pkg</string>
                     <key>resources</key>
                     <string>Resources</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._