### PR TITLE
Adobe Reader fixes

### DIFF
--- a/AdobeReader/AdobeReader.munki.recipe
+++ b/AdobeReader/AdobeReader.munki.recipe
@@ -52,6 +52,14 @@ if [ -e "/Applications/Adobe Acrobat Reader.app" ]; then
 fi
 if [ -e "/Applications/Adobe Acrobat Reader DC.app" ]; then
 	rm -r "/Applications/Adobe Acrobat Reader DC.app"
+if [ -e "/Applications/Adobe Acrobat Reader.app" ]; then
+rm -r "/Applications/Adobe Acrobat Reader.app"
+fi
+if [ -e "/Applications/Adobe Acrobat Reader DC.app" ]; then
+rm -r "/Applications/Adobe Acrobat Reader DC.app"
+fi
+if [ -e "/Applications/Adobe Acrobat DC/Adobe Acrobat.app" ]; then
+rm -r "/Applications/Adobe Acrobat DC/Adobe Acrobat.app"
 fi
 exit 0
 </string>

--- a/AdobeReader/AdobeReader.munki.recipe
+++ b/AdobeReader/AdobeReader.munki.recipe
@@ -52,14 +52,12 @@ if [ -e "/Applications/Adobe Acrobat Reader.app" ]; then
 fi
 if [ -e "/Applications/Adobe Acrobat Reader DC.app" ]; then
 	rm -r "/Applications/Adobe Acrobat Reader DC.app"
-if [ -e "/Applications/Adobe Acrobat Reader.app" ]; then
-rm -r "/Applications/Adobe Acrobat Reader.app"
 fi
-if [ -e "/Applications/Adobe Acrobat Reader DC.app" ]; then
-rm -r "/Applications/Adobe Acrobat Reader DC.app"
+if [ -e "/Applications/Adobe Acrobat Reader.app" ]; then
+	rm -r "/Applications/Adobe Acrobat Reader.app"
 fi
 if [ -e "/Applications/Adobe Acrobat DC/Adobe Acrobat.app" ]; then
-rm -r "/Applications/Adobe Acrobat DC/Adobe Acrobat.app"
+	rm -r "/Applications/Adobe Acrobat DC/Adobe Acrobat.app"
 fi
 exit 0
 </string>

--- a/AdobeReader/AdobeReader.munki.recipe
+++ b/AdobeReader/AdobeReader.munki.recipe
@@ -53,9 +53,6 @@ fi
 if [ -e "/Applications/Adobe Acrobat Reader DC.app" ]; then
 	rm -r "/Applications/Adobe Acrobat Reader DC.app"
 fi
-if [ -e "/Applications/Adobe Acrobat Reader.app" ]; then
-	rm -r "/Applications/Adobe Acrobat Reader.app"
-fi
 if [ -e "/Applications/Adobe Acrobat DC/Adobe Acrobat.app" ]; then
 	rm -r "/Applications/Adobe Acrobat DC/Adobe Acrobat.app"
 fi

--- a/AdobeReader/AdobeReader.munki.recipe
+++ b/AdobeReader/AdobeReader.munki.recipe
@@ -112,7 +112,7 @@ exit 0
 				<string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
 				<array>
-					<string>/Applications/Adobe Acrobat DC/Adobe Acrobat.app</string>
+					<string>/Applications/Adobe Acrobat.app</string>
 				</array>
 			</dict>
 			<key>Processor</key>
@@ -198,8 +198,8 @@ fi
 
 echo "No Adobe Acrobat DC Unified App found with AcroSCA=True"
 
-# Check if Adobe Acrobat Reader.app is installed
-reader_app_path="/Applications/Adobe Acrobat Reader.app"
+# Check if Adobe Acrobat.app is installed
+reader_app_path="/Applications/Adobe Acrobat.app"
 reader_plist_path="$reader_app_path/Contents/Info.plist"
 munki_version="%app_version%"
 

--- a/AdobeReader/AdobeReader.munki.recipe
+++ b/AdobeReader/AdobeReader.munki.recipe
@@ -93,7 +93,7 @@ exit 0
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkg_unpack/application.pkg/Payload</string>
+				<string>%RECIPE_CACHE_DIR%/pkg_unpack/application_mini_7z.pkg/Payload</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/application_payload/Applications</string>
 				<key>purge_destination</key>
@@ -109,7 +109,7 @@ exit 0
 				<string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
 				<array>
-					<string>/Applications/Adobe Acrobat Reader.app</string>
+					<string>/Applications/Adobe Acrobat DC/Adobe Acrobat.app</string>
 				</array>
 			</dict>
 			<key>Processor</key>
@@ -123,7 +123,7 @@ exit 0
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/application_payload/Applications/Adobe Acrobat Reader.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/application_payload/Applications/Adobe Acrobat.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Adobe looks to have changed the inner package.
```
PkgRootCreator: Created /Users/zack_mccauley/Library/AutoPkg/Cache/local.munki.AdobeReader/application_payload/Applications
PkgPayloadUnpacker
extraction of /Users/zack_mccauley/Library/AutoPkg/Cache/local.munki.AdobeReader/pkg_unpack/application.pkg/Payload with aa failed
Failed.
Receipt written to /Users/zack_mccauley/Library/AutoPkg/Cache/local.munki.AdobeReader/receipts/AdobeReader.munki-receipt-20260403-120143.plist

The following recipes failed:
    AdobeReader.munki.recipe
        Error in local.munki.AdobeReader: Processor: PkgPayloadUnpacker: Error: extraction of /Users/zack_mccauley/Library/AutoPkg/Cache/local.munki.AdobeReader/pkg_unpack/application.pkg/Payload with aa failed
```


This fixes the path inside the package and the applications location:
```
...
 'verbose': 4,
 'version': '25.001.21288'}
Receipt written to /Users/zack_mccauley/Library/AutoPkg/Cache/local.munki.AdobeReader/receipts/AdobeReader.munki-receipt-20260403-122351.plist

The following new items were imported into Munki:
    Name           Version       Catalogs    Pkginfo Path                                             Pkg Repo Path                                          Icon Repo Path
    ----           -------       --------    ------------                                             -------------                                          --------------
    AdobeReaderDC  25.001.21288  production  apps/Adobe/AdobeReader/AdobeReaderDC-25.001.21288.plist  apps/Adobe/AdobeReader/AdobeReaderDC-25.001.21288.dmg
  ```