### PR TITLE
Add ARCH input to Dropbox download recipe

### DIFF
--- a/Dropbox/Dropbox.download.recipe
+++ b/Dropbox/Dropbox.download.recipe
@@ -3,17 +3,19 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Dropbox. Change the BUILD value from 'stable' to 'beta' for beta builds.</string>
+    <string>Downloads the current release version of Dropbox. Set BUILD to "stable" (default) or "beta". Set ARCH to "arm64" for Apple Silicon or leave blank for Intel.</string>
     <key>Identifier</key>
     <string>com.github.autopkg.download.dropbox</string>
     <key>Input</key>
     <dict>
-        <key>NAME</key>
-        <string>Dropbox</string>
-        <key>DOWNLOADURL</key>
-        <string>https://www.dropbox.com/download?plat=mac&amp;full=1&amp;build=%BUILD%</string>
+        <key>ARCH</key>
+        <string></string>
         <key>BUILD</key>
         <string>stable</string>
+        <key>DOWNLOADURL</key>
+        <string>https://www.dropbox.com/download?plat=mac&amp;full=1&amp;build=%BUILD%&amp;arch=%ARCH%</string>
+        <key>NAME</key>
+        <string>Dropbox</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>


### PR DESCRIPTION
## Summary

Dropbox provides architecture-specific Mac installers via the `&arch=` query parameter on their download API. This PR adds an `ARCH` input variable so downstream consumers can request Apple Silicon builds cleanly, without needing to overload the `BUILD` variable.

### Valid `ARCH` values
| Value | Downloads |
|---|---|
| *(blank, default)* | Intel (preserves existing behavior) |
| `arm64` | Apple Silicon |

### Testing

Default (Intel):
```
$ autopkg run -vvq Dropbox.download --check

Processing Dropbox.download.recipe...
URLDownloader
{'Input': {'filename': 'Dropbox.dmg',
           'url': 'https://www.dropbox.com/download?plat=mac&full=1&build=stable&arch='}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Downloaded <CACHE>/Dropbox.dmg
{'Output': {'download_changed': True,
            'pathname': '<CACHE>/Dropbox.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '<CACHE>/Dropbox.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to <CACHE>/receipts/Dropbox.download-receipt-20260403-133912.plist

The following new items were downloaded:
    Download Path
    -------------
    <CACHE>/Dropbox.dmg
```

Redirects to Intel DMG (`Dropbox 246.4.3513.dmg`), confirmed x86_64 binary.

Apple Silicon (`-k ARCH=arm64`):
```
$ autopkg run -vvq Dropbox.download --check -k ARCH=arm64

Processing Dropbox.download.recipe...
URLDownloader
{'Input': {'filename': 'Dropbox.dmg',
           'url': 'https://www.dropbox.com/download?plat=mac&full=1&build=stable&arch=arm64'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Downloaded <CACHE>/Dropbox.dmg
{'Output': {'download_changed': True,
            'pathname': '<CACHE>/Dropbox.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '<CACHE>/Dropbox.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to <CACHE>/receipts/Dropbox.download-receipt-20260403-134207.plist

The following new items were downloaded:
    Download Path
    -------------
    <CACHE>/Dropbox.dmg
```

Redirects to arm64 DMG (`Dropbox 246.4.3513.arm64.dmg`), confirmed arm64 binary via `lipo -archs`.