### PR TITLE
Accommodate software titles that fail strict verification

### DIFF
--- a/Dropbox/Dropbox.download.recipe
+++ b/Dropbox/Dropbox.download.recipe
@@ -45,6 +45,8 @@
                 <string>%pathname%/Dropbox.app</string>
                 <key>requirement</key>
                 <string>identifier "com.getdropbox.dropbox" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = G7HH3F8CAK</string>
+                <key>strict_verification</key>
+                <false/>
             </dict>
         </dict>
     </array>

--- a/OmniGroup/OmniDiskSweeper.download.recipe
+++ b/OmniGroup/OmniDiskSweeper.download.recipe
@@ -24,6 +24,8 @@
 				<string>%pathname%/OmniDiskSweeper.app</string>
 				<key>requirement</key>
 				<string>identifier "com.omnigroup.OmniDiskSweeper" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "34YW5XSRB7"</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/OmniGroup/OmniFocus4.download.recipe
+++ b/OmniGroup/OmniFocus4.download.recipe
@@ -26,6 +26,8 @@
                 <string>%pathname%/OmniFocus.app</string>
                 <key>requirement</key>
                 <string>identifier "com.omnigroup.OmniFocus4" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "34YW5XSRB7"</string>
+                <key>strict_verification</key>
+                <false/>
             </dict>
         </dict>
     </array>

--- a/OmniGroup/OmniGraffle7.download.recipe
+++ b/OmniGroup/OmniGraffle7.download.recipe
@@ -26,6 +26,8 @@
                 <string>%pathname%/OmniGraffle.app</string>
                 <key>requirement</key>
                 <string>identifier "com.omnigroup.OmniGraffle7" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "34YW5XSRB7"</string>
+                <key>strict_verification</key>
+                <false/>
             </dict>
         </dict>
     </array>

--- a/OmniGroup/OmniOutliner5.download.recipe
+++ b/OmniGroup/OmniOutliner5.download.recipe
@@ -26,6 +26,8 @@
                 <string>%pathname%/OmniOutliner.app</string>
                 <key>requirement</key>
                 <string>identifier "com.omnigroup.OmniOutliner5" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "34YW5XSRB7"</string>
+                <key>strict_verification</key>
+                <false/>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
This PR adds `strict_verification: false` to the `CodeSignatureVerifier` step(s) in one or more of your download recipes.

The next version of AutoPkg will likely change `CodeSignatureVerifier` so that `strict_verification` defaults to true instead of false. Under strict verification, `codesign --strict` rejects apps with specific build anomalies (e.g. `com.apple.FinderInfo`, resource forks) — which currently affect recipes in this repo.

Setting `strict_verification: false` explicitly opts these recipes out of that upcoming default so they keep working after the release. Because `false` is also the *current* default, this change is safe to merge. The recipe is simply being pinned to its existing verification behavior.

To confirm the change works, a comment on this PR includes the verbatim `autopkg run -vv` output showing the recipe still verifies successfully with the change applied.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.