### PR TITLE
Cleanup temporary Google Chrome Pkg directories

### DIFF
--- a/GoogleChrome/GoogleChromePkg.munki.recipe
+++ b/GoogleChrome/GoogleChromePkg.munki.recipe
@@ -119,6 +119,18 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
 				<key>Processor</key>
 				<string>MunkiImporter</string>
 			</dict>
+			<dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/payload</string>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+				</array>
+			</dict>
+		</dict>
 		</array>
 	</dict>
 </plist>


### PR DESCRIPTION
This PR cleans up the `payload` and `unpack` directories when running the `GoogleChromePkg.munki.recipe` AutoPkg recipe :sparkles:

Adding this `PathDeleter` processor step saves approximately **1GB** of disk space, i.e. `Google Chrome.app` and `GoogleChrome.pkg` :broom: