### PR TITLE
AdobeReader.munki: force munki version via --pkgvers (new installer filename breaks version detection)

### DIFF
--- a/AdobeReader/AdobeReader.munki.recipe
+++ b/AdobeReader/AdobeReader.munki.recipe
@@ -128,6 +128,11 @@ exit 0
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>additional_makepkginfo_options</key>
+				<array>
+					<string>--pkgvers</string>
+					<string>%version%</string>
+				</array>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>


### PR DESCRIPTION
Adobe renamed the Reader installer from `AcroRdrDC_<version>_MUI.dmg` to `AdobeReader<version>.dmg` (current: `AdobeReader2600121662.dmg`).

With the new naming, `makepkginfo`'s name/version heuristic splits the trailing digits off the pkg name, so the imported pkginfo gets `version: 2600121662` instead of `26.001.21662`. The receipts keep the dotted versions (the Distribution has no product version attribute), but the item version is wrong.

This is worse than cosmetic: munki's version comparison treats `2600121662` as a single huge number, so this item sorts **above every future 26.x/27.x release** — clients stick to it and never see another Reader update.

Repro:
```
% makepkginfo AdobeReader2600121662.dmg | plutil -extract version raw -o - -- -
2600121662
```

Fix: pass the properly dotted version that `AdobeReaderURLProvider` already returns (from Adobe's RDC API, e.g. `26.001.21662`) to makepkginfo via `additional_makepkginfo_options --pkgvers`. Older installers with the previous naming are unaffected by this change — the explicit version matches what the heuristic used to fall back to.