### PR TITLE
Update MSOfficeUpdates for Microsoft's manifest feed changes

### DIFF
--- a/MSOfficeUpdates/MSAutoUpdate.download.recipe
+++ b/MSOfficeUpdates/MSAutoUpdate.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION currently only supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>
@@ -28,8 +23,6 @@ the latest full update for the given CHANNEL.
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSAutoUpdate</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSAutoUpdate.munki.recipe
+++ b/MSOfficeUpdates/MSAutoUpdate.munki.recipe
@@ -16,11 +16,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION currently only supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>

--- a/MSOfficeUpdates/MSCompanyPortal.download.recipe
+++ b/MSOfficeUpdates/MSCompanyPortal.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>CompanyPortal</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSDefenderATP.download.recipe
+++ b/MSOfficeUpdates/MSDefenderATP.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSDefenderATP</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSDefenderATP.munki.recipe
+++ b/MSOfficeUpdates/MSDefenderATP.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',

--- a/MSOfficeUpdates/MSEdge.download.recipe
+++ b/MSOfficeUpdates/MSEdge.download.recipe
@@ -10,11 +10,6 @@ CHANNEL supports 'Production', 'InsiderSlow' and 'InsiderFast', which map
 to the Edge Enterprise API's Stable, Beta and Dev channels. Custom UUID
 channels are not supported for Edge.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>
@@ -26,8 +21,6 @@ the latest full update for the given CHANNEL.
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSEdge</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSEdge.download.recipe
+++ b/MSOfficeUpdates/MSEdge.download.recipe
@@ -6,11 +6,9 @@
     <string>Downloads the latest Microsoft Edge pkg,
 and appends the version to the end of the filename.
 
-CHANNEL can be set to several values in order to get more frequent updates
-that can be used for testing purposes. See the explanations in the 'Channel'
-table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
-values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
-inserted into the Base URL.
+CHANNEL supports 'Production', 'InsiderSlow' and 'InsiderFast', which map
+to the Edge Enterprise API's Stable, Beta and Dev channels. Custom UUID
+channels are not supported for Edge.
 
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See

--- a/MSOfficeUpdates/MSEdge.munki.recipe
+++ b/MSOfficeUpdates/MSEdge.munki.recipe
@@ -13,11 +13,9 @@ pkginfo Input override below.
 CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
-CHANNEL can be set to several values in order to get more frequent updates
-that can be used for testing purposes. See the explanations in the 'Channel'
-table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
-values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
-inserted into the Base URL.
+CHANNEL supports 'Production', 'InsiderSlow' and 'InsiderFast', which map
+to the Edge Enterprise API's Stable, Beta and Dev channels. Custom UUID
+channels are not supported for Edge.
 
 LOCALE_ID sets the locale for a descriptive text that will be
 extracted from the Microsoft update metadata. See
@@ -79,7 +77,7 @@ the latest full update for the given CHANNEL.
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>version_comparison_key</key>
-                <string>CFBundleVersion</string>
+                <string>CFBundleShortVersionString</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>

--- a/MSOfficeUpdates/MSEdge.munki.recipe
+++ b/MSOfficeUpdates/MSEdge.munki.recipe
@@ -10,17 +10,12 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL supports 'Production', 'InsiderSlow' and 'InsiderFast', which map
 to the Edge Enterprise API's Stable, Beta and Dev channels. Custom UUID
 channels are not supported for Edge.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.

--- a/MSOfficeUpdates/MSExcel2016.download.recipe
+++ b/MSOfficeUpdates/MSExcel2016.download.recipe
@@ -27,7 +27,7 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSExcel2016</string>
     <key>MinimumVersion</key>
-    <string>1.4</string>
+    <string>2.9</string>
     <key>Input</key>
     <dict>
         <key>CHANNEL</key>

--- a/MSOfficeUpdates/MSExcel2016.download.recipe
+++ b/MSOfficeUpdates/MSExcel2016.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSExcel2016</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSExcel2016.munki.recipe
+++ b/MSOfficeUpdates/MSExcel2016.munki.recipe
@@ -16,11 +16,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,

--- a/MSOfficeUpdates/MSExcel2019.download.recipe
+++ b/MSOfficeUpdates/MSExcel2019.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSExcel2019</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSExcel2019.munki.recipe
+++ b/MSOfficeUpdates/MSExcel2019.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',

--- a/MSOfficeUpdates/MSOfficeMacProduct.download.recipe
+++ b/MSOfficeUpdates/MSOfficeMacProduct.download.recipe
@@ -16,11 +16,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -36,8 +31,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MicrosoftOfficeMacProduct</string>
         <key>PRODUCT</key>
@@ -54,8 +47,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
             <dict>
                 <key>channel</key>
                 <string>%CHANNEL%</string>
-                <key>locale_id</key>
-                <string>%LOCALE_ID%</string>
                 <key>product</key>
                 <string>%PRODUCT%</string>
                 <key>version</key>

--- a/MSOfficeUpdates/MSOfficeMacProduct.download.recipe
+++ b/MSOfficeUpdates/MSOfficeMacProduct.download.recipe
@@ -31,7 +31,7 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSOfficeMacProduct</string>
     <key>MinimumVersion</key>
-    <string>1.4</string>
+    <string>2.0.1</string>
     <key>Input</key>
     <dict>
         <key>CHANNEL</key>

--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -167,6 +167,15 @@ CHANNELS = {
 }
 DEFAULT_CHANNEL = "Production"
 NO_TRIGGER_CONDITIONS = ["SkypeForBusiness", "Teams", "Teams2", "CompanyPortal"]
+# Office 2016 reached end of support in October 2020 at 16.16.27, and Microsoft
+# no longer publishes these products to the update feed.
+DEPRECATED_PRODUCTS = [
+    "Excel2016",
+    "OneNote2016",
+    "Outlook2016",
+    "PowerPoint2016",
+    "Word2016",
+]
 
 
 class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
@@ -546,6 +555,15 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
                 % "', '".join(SUPPORTED_VERSIONS)
             )
         product = self.env["product"]
+        if product in DEPRECATED_PRODUCTS:
+            self.show_deprecation(
+                "As of August 2026, Microsoft no longer publishes %s updates to "
+                "the Microsoft AutoUpdate feed. Office for Mac 2016 support ended "
+                "in October 2020 at version 16.16.27. Please use the MS%s recipes "
+                "instead." % (product, product.replace("2016", "2019"))
+            )
+            self.env["stop_processing_recipe"] = True
+            return
         if product == "Edge":
             self.get_edge_installer_info()
             return

--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -17,10 +17,11 @@
 # limitations under the License.
 """See docstring for MSOfficeMacURLandUpdateInfoProvider class"""
 
+import json
 import plistlib
 import re
 
-from autopkglib import ProcessorError, version_equal_or_greater
+from autopkglib import APLooseVersion, ProcessorError, version_equal_or_greater
 from autopkglib.URLGetter import URLGetter
 
 __all__ = ["MSOfficeMacURLandUpdateInfoProvider"]
@@ -31,6 +32,26 @@ CULTURE_CODE = "0409"
 BASE_URL = (
     "https://res.public.onecdn.static.microsoft/mro1cdnstorage/%s/MacAutoupdate/%s.xml"
 )
+EDGE_ENTERPRISE_API_URL = (
+    "https://edgeupdates.microsoft.com/api/products?view=enterprise"
+)
+EDGE_ENTERPRISE_CHANNELS = {
+    "Production": {
+        "channel": "Stable",
+        "bundle_id": "com.microsoft.edgemac",
+        "path": "/Applications/Microsoft Edge.app",
+    },
+    "InsiderSlow": {
+        "channel": "Beta",
+        "bundle_id": "com.microsoft.edgemac.Beta",
+        "path": "/Applications/Microsoft Edge Beta.app",
+    },
+    "InsiderFast": {
+        "channel": "Dev",
+        "bundle_id": "com.microsoft.edgemac.Dev",
+        "path": "/Applications/Microsoft Edge Dev.app",
+    },
+}
 
 # These can be easily be found as "Application ID" in
 # ~/Library/Preferences/com.microsoft.autoupdate2.plist on a
@@ -145,11 +166,12 @@ CHANNELS = {
     "InsiderFast": "4B2D7701-0A4F-49C8-B4CB-0C2D4043F51F",
 }
 DEFAULT_CHANNEL = "Production"
-NO_TRIGGER_CONDITIONS = ["SkypeForBusiness", "Teams", "Teams2", "Edge", "CompanyPortal"]
+NO_TRIGGER_CONDITIONS = ["SkypeForBusiness", "Teams", "Teams2", "CompanyPortal"]
 
 
 class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
-    """Provides a download URL for the most recent version of MS Office 2016."""
+    """Provides a download URL and update info for Microsoft Mac products, from
+    the Microsoft AutoUpdate manifest feed or, for Edge, the Edge Enterprise API."""
 
     input_variables = {
         "locale_id": {
@@ -171,8 +193,8 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
             "default": DEFAULT_VERSION,
             "description": (
                 "Update type to fetch. Supported values are: "
-                "'%s'. Defaults to %s."
-                % ("', '".join(SUPPORTED_VERSIONS), DEFAULT_VERSION)
+                "'%s'. Defaults to %s. Edge supports only '%s'."
+                % ("', '".join(SUPPORTED_VERSIONS), DEFAULT_VERSION, DEFAULT_VERSION)
             ),
         },
         "munki_required_update_name": {
@@ -191,7 +213,9 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
             "description": (
                 "Update feed channel that will be checked for updates. "
                 "Defaults to %s, acceptable values are either a custom "
-                "UUID or one of: %s" % (DEFAULT_CHANNEL, ", ".join(CHANNELS))
+                "UUID or one of: %s. Edge accepts only the named channels, "
+                "which map to the Edge Enterprise API's Stable, Beta and Dev."
+                % (DEFAULT_CHANNEL, ", ".join(CHANNELS))
             ),
         },
     }
@@ -269,6 +293,86 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
                 % item["Update Version"]
             )
             return item["Update Version"]
+
+    def get_edge_installer_info(self):
+        """Gets Microsoft Edge installer info from the Edge Enterprise API."""
+        if self.env["version"] != "latest":
+            raise ProcessorError("Edge supports only VERSION 'latest'.")
+
+        channel_input = self.env.get("channel", DEFAULT_CHANNEL)
+        if channel_input not in EDGE_ENTERPRISE_CHANNELS:
+            raise ProcessorError(
+                "Edge CHANNEL must be one of: %s. Custom UUID channels are not "
+                "supported by the Edge Enterprise API."
+                % ", ".join(EDGE_ENTERPRISE_CHANNELS)
+            )
+        edge = EDGE_ENTERPRISE_CHANNELS[channel_input]
+        edge_channel = edge["channel"]
+
+        self.output("Requesting Edge Enterprise API: %s" % EDGE_ENTERPRISE_API_URL)
+        products = json.loads(self.download(EDGE_ENTERPRISE_API_URL))
+
+        product = next(
+            (
+                item
+                for item in products
+                if item.get("Product", "").lower() == edge_channel.lower()
+            ),
+            None,
+        )
+        if not product:
+            raise ProcessorError(
+                "Could not find Edge channel '%s' in Enterprise API response."
+                % edge_channel
+            )
+
+        releases = []
+        for release in product.get("Releases", []):
+            if (
+                release.get("Platform", "").lower() != "macos"
+                or release.get("Architecture", "").lower() != "universal"
+            ):
+                continue
+            artifact = next(
+                (
+                    item
+                    for item in release.get("Artifacts") or []
+                    if item.get("ArtifactName", "").lower() == "pkg"
+                    or item.get("Location", "").lower().endswith(".pkg")
+                ),
+                None,
+            )
+            if artifact and release.get("ProductVersion") and artifact.get("Location"):
+                releases.append((release, artifact))
+
+        if not releases:
+            raise ProcessorError(
+                "Could not find a macOS universal pkg release for Edge channel '%s'."
+                % edge_channel
+            )
+
+        release, artifact = max(
+            releases,
+            key=lambda item: APLooseVersion(item[0]["ProductVersion"]),
+        )
+        version = release["ProductVersion"]
+        self.env["version"] = version
+        self.env["minimum_version_for_delta"] = ""
+        self.env["url"] = artifact["Location"].strip()
+        self.env["additional_pkginfo"] = {
+            "installs": [
+                {
+                    "CFBundleIdentifier": edge["bundle_id"],
+                    "CFBundleShortVersionString": version,
+                    "path": edge["path"],
+                    "type": "application",
+                }
+            ],
+        }
+
+        self.output("Found Edge %s version %s" % (edge_channel, version))
+        self.output("Found URL %s" % self.env["url"])
+        self.output("Additional pkginfo: %s" % self.env["additional_pkginfo"])
 
     def get_installer_info(self):
         """Gets info about an installer from MS metadata."""
@@ -441,6 +545,10 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
                 "Invalid 'version': supported values are '%s'"
                 % "', '".join(SUPPORTED_VERSIONS)
             )
+        product = self.env["product"]
+        if product == "Edge":
+            self.get_edge_installer_info()
+            return
         self.get_installer_info()
 
 

--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -157,7 +157,6 @@ PROD_DICT = {
         "minimum_os": "12.0",
     },
 }
-LOCALE_ID_INFO_URL = "https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx"
 SUPPORTED_VERSIONS = ["latest", "latest-delta", "latest-standalone"]
 DEFAULT_VERSION = "latest"
 CHANNELS = {
@@ -183,16 +182,6 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
     the Microsoft AutoUpdate manifest feed or, for Edge, the Edge Enterprise API."""
 
     input_variables = {
-        "locale_id": {
-            "required": False,
-            "default": "1033",
-            "description": (
-                "Locale ID that determines the language "
-                "that is retrieved from the metadata, currently only "
-                "used by the update description. See %s "
-                "for a list of locale codes. The default is en-US." % LOCALE_ID_INFO_URL
-            ),
-        },
         "product": {
             "required": True,
             "description": "Name of product to fetch, e.g. Excel.",
@@ -231,12 +220,6 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
     output_variables = {
         "additional_pkginfo": {
             "description": "Some pkginfo fields extracted from the Microsoft metadata."
-        },
-        "description": {
-            "description": (
-                "Description of the update from the manifest, in the language "
-                "given by the locale_id input variable."
-            )
         },
         "version": {
             "description": (

--- a/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
+++ b/MSOfficeUpdates/MSOfficeMacURLandUpdateInfoProvider.py
@@ -28,7 +28,9 @@ __all__ = ["MSOfficeMacURLandUpdateInfoProvider"]
 # CULTURE_CODE defaulting to 'en-US' as the installers and updates seem to be
 # multilingual.
 CULTURE_CODE = "0409"
-BASE_URL = "https://officecdnmac.microsoft.com/pr/%s/MacAutoupdate/%s.xml"
+BASE_URL = (
+    "https://res.public.onecdn.static.microsoft/mro1cdnstorage/%s/MacAutoupdate/%s.xml"
+)
 
 # These can be easily be found as "Application ID" in
 # ~/Library/Preferences/com.microsoft.autoupdate2.plist on a
@@ -302,14 +304,19 @@ class MSOfficeMacURLandUpdateInfoProvider(URLGetter):
         data = self.download(base_url, headers)
 
         metadata = plistlib.loads(data)
+        if not isinstance(metadata, list):
+            raise ProcessorError(
+                "No update metadata returned for product '%s' from %s. This "
+                "product may no longer be published to the update feed."
+                % (self.env["product"], base_url)
+            )
         # Upstream feed has emitted Location values with stray newlines
         # that break curl; normalize whitespace on all string values.
-        if isinstance(metadata, list):
-            metadata = [
-                {k: v.strip() if isinstance(v, str) else v for k, v in entry.items()}
-                for entry in metadata
-                if isinstance(entry, dict)
-            ]
+        metadata = [
+            {k: v.strip() if isinstance(v, str) else v for k, v in entry.items()}
+            for entry in metadata
+            if isinstance(entry, dict)
+        ]
         item = {}
         # Update feeds for a given 'channel' will have either combo or delta
         # pkg urls, with delta's additionally having a 'FullUpdaterLocation'

--- a/MSOfficeUpdates/MSOneNote2016.download.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION currently only supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>
@@ -28,8 +23,6 @@ the latest full update for the given CHANNEL.
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSOneNote2016</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSOneNote2016.download.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.download.recipe
@@ -23,7 +23,7 @@ the latest full update for the given CHANNEL.
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSOneNote2016</string>
     <key>MinimumVersion</key>
-    <string>1.4</string>
+    <string>2.9</string>
     <key>Input</key>
     <dict>
         <key>CHANNEL</key>

--- a/MSOfficeUpdates/MSOneNote2016.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2016.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION currently only supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.

--- a/MSOfficeUpdates/MSOneNote2019.download.recipe
+++ b/MSOfficeUpdates/MSOneNote2019.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION currently only supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>
@@ -28,8 +23,6 @@ the latest full update for the given CHANNEL.
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSOneNote2019</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSOneNote2019.munki.recipe
+++ b/MSOfficeUpdates/MSOneNote2019.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION currently only supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.

--- a/MSOfficeUpdates/MSOutlook2016.download.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSOutlook2016</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSOutlook2016.download.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.download.recipe
@@ -27,7 +27,7 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSOutlook2016</string>
     <key>MinimumVersion</key>
-    <string>1.4</string>
+    <string>2.9</string>
     <key>Input</key>
     <dict>
         <key>CHANNEL</key>

--- a/MSOfficeUpdates/MSOutlook2016.munki.recipe
+++ b/MSOfficeUpdates/MSOutlook2016.munki.recipe
@@ -16,11 +16,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,

--- a/MSOfficeUpdates/MSOutlook2019.download.recipe
+++ b/MSOfficeUpdates/MSOutlook2019.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSOutlook2019</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSOutlook2019.munki.recipe
+++ b/MSOfficeUpdates/MSOutlook2019.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',

--- a/MSOfficeUpdates/MSPowerPoint2016.download.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.download.recipe
@@ -27,7 +27,7 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSPowerPoint2016</string>
     <key>MinimumVersion</key>
-    <string>1.4</string>
+    <string>2.9</string>
     <key>Input</key>
     <dict>
         <key>CHANNEL</key>

--- a/MSOfficeUpdates/MSPowerPoint2016.download.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSPowerPoint2016</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2016.munki.recipe
@@ -16,11 +16,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,

--- a/MSOfficeUpdates/MSPowerPoint2019.download.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2019.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSPowerPoint2019</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSPowerPoint2019.munki.recipe
+++ b/MSOfficeUpdates/MSPowerPoint2019.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',

--- a/MSOfficeUpdates/MSRemoteDesktop.download.recipe
+++ b/MSOfficeUpdates/MSRemoteDesktop.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>
@@ -28,8 +23,6 @@ the latest full update for the given CHANNEL.
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSRemoteDesktop</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSRemoteDesktop.munki.recipe
+++ b/MSOfficeUpdates/MSRemoteDesktop.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.

--- a/MSOfficeUpdates/MSTeams.download.recipe
+++ b/MSOfficeUpdates/MSTeams.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>
@@ -28,8 +23,6 @@ the latest full update for the given CHANNEL.
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSTeams</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSTeams.munki.recipe
+++ b/MSOfficeUpdates/MSTeams.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.

--- a/MSOfficeUpdates/MSTeams2.download.recipe
+++ b/MSOfficeUpdates/MSTeams2.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>
@@ -28,8 +23,6 @@ the latest full update for the given CHANNEL.
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSTeams</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSTeams2.munki.recipe
+++ b/MSOfficeUpdates/MSTeams2.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.

--- a/MSOfficeUpdates/MSWord2016.download.recipe
+++ b/MSOfficeUpdates/MSWord2016.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSWord2016</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSWord2016.download.recipe
+++ b/MSOfficeUpdates/MSWord2016.download.recipe
@@ -27,7 +27,7 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <key>Identifier</key>
     <string>com.github.autopkg.download.MSWord2016</string>
     <key>MinimumVersion</key>
-    <string>1.4</string>
+    <string>2.9</string>
     <key>Input</key>
     <dict>
         <key>CHANNEL</key>

--- a/MSOfficeUpdates/MSWord2016.munki.recipe
+++ b/MSOfficeUpdates/MSWord2016.munki.recipe
@@ -16,11 +16,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,

--- a/MSOfficeUpdates/MSWord2019.download.recipe
+++ b/MSOfficeUpdates/MSWord2019.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',
 which will download the latest delta update for the given CHANNEL,
@@ -32,8 +27,6 @@ installer for the given CHANNEL. 'latest-standalone' does not support
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>MSWord2019</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/MSWord2019.munki.recipe
+++ b/MSOfficeUpdates/MSWord2019.munki.recipe
@@ -10,7 +10,7 @@ Munki.
 If this is an update_for something, you may define this in your
 pkginfo Input override below.
 
-CHANNEL, LOCALE_ID, and VERSION are inherited from the .download recipe but can
+CHANNEL and VERSION are inherited from the .download recipe but can
 still be overridden in an override for this .munki recipe.
 
 CHANNEL can be set to several values in order to get more frequent updates
@@ -18,11 +18,6 @@ that can be used for testing purposes. See the explanations in the 'Channel'
 table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
-
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
 
 VERSION supports three values: 'latest', which will download
 the latest full update for the given CHANNEL, 'latest-delta',

--- a/MSOfficeUpdates/SkypeForBusiness.download.recipe
+++ b/MSOfficeUpdates/SkypeForBusiness.download.recipe
@@ -12,11 +12,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION currently only supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>
@@ -28,8 +23,6 @@ the latest full update for the given CHANNEL.
     <dict>
         <key>CHANNEL</key>
         <string>Production</string>
-        <key>LOCALE_ID</key>
-        <string>1033</string>
         <key>NAME</key>
         <string>SkypeForBusiness</string>
         <key>PRODUCT</key>

--- a/MSOfficeUpdates/SkypeForBusiness.munki.recipe
+++ b/MSOfficeUpdates/SkypeForBusiness.munki.recipe
@@ -16,11 +16,6 @@ table at http://macadmins.software/docs/MAU_ManifestServer.pdf. Supported
 values are 'Production', 'InsiderSlow', 'InsiderFast', or a custom UUID to be
 inserted into the Base URL.
 
-LOCALE_ID sets the locale for a descriptive text that will be
-extracted from the Microsoft update metadata. See
-https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx
-for more information about locale IDs.
-
 VERSION currently only supports one value: 'latest', which will download
 the latest full update for the given CHANNEL.
 </string>


### PR DESCRIPTION
Microsoft moved the MAU manifest feed to a new CDN and left the old host up, still serving a frozen copy. Nothing errors, so recipes download a real signed package and report a stale version as current. It shows up downstream instead, as Munki refusing to import.

Switching `BASE_URL` to the new host fixes Office, MAU, Defender, Teams, Company Portal, OneDrive, Remote Desktop and Skype for Business. Thanks to @ahajjarcp for spotting the new URL, and to @gregneagle, @pnerum, @bjohnson-MHC and @carlashley for confirming it across channels and VERSION values in #561.

Edge is on the new host but hasn't been updated there either, still sitting on a 134.x manifest from March 2025, so it moves to the Edge Enterprise API instead and picks up 151.0.4129.59. Two limits come with that, both from the API rather than a choice: Edge only supports VERSION `latest`, and CHANNEL has to be Production, InsiderSlow or InsiderFast, since a custom UUID channel isn't something the Edge API knows about. Each channel now gets its own installs metadata, since Beta and Dev install alongside Stable as `com.microsoft.edgemac.Beta` and `.Dev`. The API publishes no minimum OS, so Edge pkginfo no longer carries one rather than carrying the stale 10.11 from `PROD_DICT`. `MSEdge.munki` compares on `CFBundleShortVersionString`, which is Edge's real version format. Worth knowing if you run the Insider channels: `blocking_applications` in `MSEdge.munki` is still Stable-only, same as before this change.

The Office 2016 products aren't on the new host at all, and that one's expected. 2016 lost support in October 2020 at 16.16.27, which is exactly what the old feed was still handing out. Rather than a `DeprecationWarning` step in each recipe, the processor warns for those products and stops the recipe before the fetch, so the notice reaches the run summary for the `.munki` children too. That needs AutoPkg 2.9 for `show_deprecation`, so those five recipes declare it. `MSOfficeMacProduct` moves to 2.0.1, which is where `APLooseVersion` came in.

Last piece: `LOCALE_ID` is gone. The code that read it went away in c2e3f45 back in 2020, when Office 2019 stopped publishing descriptions, but the input variable stayed behind in every recipe. Existing overrides carrying the key are harmless.

Heads up on CI: pre-commit.ci is already failing on master, since the v1.25.1 autoupdate in #560 made `check-autopkg-recipes` stricter about `MinimumVersion`. None of those findings are in `MSOfficeUpdates`, and this branch doesn't add or remove any of them. Fixing them separately.

Closes #500. Closes #561.
