### PR TITLE
Bump MinimumVersion to match the processors in use

### DIFF
--- a/Adium/Adium.download.recipe
+++ b/Adium/Adium.download.recipe
@@ -14,7 +14,7 @@
         <string>release</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>0.4.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Cyberduck/Cyberduck.download.recipe
+++ b/Cyberduck/Cyberduck.download.recipe
@@ -19,7 +19,7 @@ Alternate URLs that can be used for SPARKLE_FEED_URL:
         <string>https://version.cyberduck.io/changelog.rss</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.4.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Dropbox/Dropbox.download.recipe
+++ b/Dropbox/Dropbox.download.recipe
@@ -18,7 +18,7 @@
         <string>Dropbox</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Evernote/Evernote.download.recipe
+++ b/Evernote/Evernote.download.recipe
@@ -12,7 +12,7 @@
         <string>Evernote</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.4.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/GoogleChrome/GoogleChrome.download.recipe
+++ b/GoogleChrome/GoogleChrome.download.recipe
@@ -14,7 +14,7 @@
         <string>https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/GoogleEarth/GoogleEarth.munki.recipe
+++ b/GoogleEarth/GoogleEarth.munki.recipe
@@ -29,7 +29,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.google-earth</string>
     <key>Process</key>

--- a/Handbrake/Handbrake.munki.recipe
+++ b/Handbrake/Handbrake.munki.recipe
@@ -29,7 +29,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.0</string>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.download.Handbrake</string>
     <key>Process</key>

--- a/Panic/Transmit.download.recipe
+++ b/Panic/Transmit.download.recipe
@@ -12,7 +12,7 @@
         <string>Transmit</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.4.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Panic/Transmit5.download.recipe
+++ b/Panic/Transmit5.download.recipe
@@ -12,7 +12,7 @@
         <string>Transmit5</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.4.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Spotify/Spotify.download.recipe
+++ b/Spotify/Spotify.download.recipe
@@ -20,7 +20,7 @@ For Intel leave DOWNLOAD_ARCH empty and set SUPPORTED_ARCH to "x86_64"</string>
         <string>arm64</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.4.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/VLC/VLC.download.recipe
+++ b/VLC/VLC.download.recipe
@@ -20,7 +20,7 @@ Allowable ARCHITECTURE values (as of October 2021) include:
         <string>universal</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.4.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/XQuartz/XQuartz.munki.recipe
+++ b/XQuartz/XQuartz.munki.recipe
@@ -37,7 +37,7 @@ The XQuartz project is an open-source effort to develop a version of the X.Org X
             </dict>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.2.5</string>
+        <string>0.3.0</string>
         <key>ParentRecipe</key>
         <string>com.github.autopkg.download.xquartz</string>
         <key>Process</key>


### PR DESCRIPTION
The v1.25.1 autoupdate in #560 made check-autopkg-recipes stricter about MinimumVersion, and twelve long-standing recipes declare a version older than the processors they use. Master has been red on pre-commit.ci since that merge.

Each bump is to exactly what the hook asks for, nothing else changed. `pre-commit run --all-files` passes with these in place.
