### PR TITLE
Add Nexus Shell recipes

### DIFF
--- a/NexusShell/NexusShell.download.recipe
+++ b/NexusShell/NexusShell.download.recipe
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest Nexus Shell disk image for Apple silicon Macs and verifies its Developer ID signature.</string>
+    <key>Identifier</key>
+    <string>com.github.autopkg.download.NexusShell</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Nexus Shell</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>asset_regex</key>
+                <string>Nexus-Shell-v[0-9]+\.[0-9]+\.[0-9]+\.dmg$</string>
+                <key>github_repo</key>
+                <string>viewer12/Nexus-Shell-Releases</string>
+            </dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Nexus Shell.app</string>
+                <key>requirement</key>
+                <string>identifier "sameral.Nexus-Shell" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5MBFAB57U2"</string>
+                <key>strict_verification</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/NexusShell/NexusShell.munki.recipe
+++ b/NexusShell/NexusShell.munki.recipe
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads and verifies the latest Nexus Shell release, then imports it into a Munki repository.</string>
+    <key>Identifier</key>
+    <string>com.github.autopkg.munki.NexusShell</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>NexusShell</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/NexusShell</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>Developer Tools</string>
+            <key>description</key>
+            <string>Native macOS SSH workspace with terminal sessions, dual-pane SFTP, SSH key management, Docker controls, and server monitoring.</string>
+            <key>developer</key>
+            <string>Nexus Shell</string>
+            <key>display_name</key>
+            <string>Nexus Shell</string>
+            <key>minimum_os_version</key>
+            <string>14.2</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>arm64</string>
+            </array>
+            <key>unattended_install</key>
+            <false/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.autopkg.download.NexusShell</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- add a download recipe for the latest Apple silicon Nexus Shell release
- verify the app with strict Developer ID signature requirements, including Team ID `5MBFAB57U2`
- add a Munki recipe with the supported architecture and minimum macOS version

I am the upstream developer of Nexus Shell. The recipes use the public GitHub Releases repository and do not require a custom processor.

## Verification

- `plutil -lint NexusShell/NexusShell.download.recipe NexusShell/NexusShell.munki.recipe`
- `uvx pre-commit run --files NexusShell/NexusShell.download.recipe NexusShell/NexusShell.munki.recipe`
- AutoPkg 2.9.0 real download run selected v1.6.9, downloaded the DMG, mounted it, and passed deep + strict `CodeSignatureVerifier` validation

## AI disclosure

Codex assisted with adapting an existing tested upstream recipe to this repository's namespace and formatting. I reviewed the complete diff and ran the checks above before requesting review.
