### PR TITLE
Update AdobeReader.download.recipe (Newer OS Input Value Change)

### DIFF
--- a/AdobeReader/AdobeReader.download.recipe
+++ b/AdobeReader/AdobeReader.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>AdobeReader</string>
 		<key>OS_VERSION</key>
-		<string>Mac OS 12.0</string>
+		<string>Mac OS 15.0</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.4</string>


### PR DESCRIPTION
increase the default value to remind the change here and to get current Version by default. Mac OS 12.0 gives Version 2026.001.21662
Mac OS 15.0 gives Version 2026.001.21771